### PR TITLE
Orphan concept after source record update

### DIFF
--- a/app/graph/neo4j/queries/update_source_record.cypher
+++ b/app/graph/neo4j/queries/update_source_record.cypher
@@ -18,11 +18,8 @@ FOREACH (abstract IN $abstracts |
 )
 
 WITH s
-OPTIONAL MATCH (s)-[r:HAS_IDENTIFIER]->(i:PublicationIdentifier)
+OPTIONAL MATCH (s)-[r:HAS_IDENTIFIER]->(:PublicationIdentifier)
 DELETE r
-WITH s, i
-  WHERE NOT (i)--(:SourceRecord)
-DELETE i
 WITH DISTINCT s
 FOREACH (identifier IN $identifiers |
   MERGE (i:PublicationIdentifier {type: identifier.type, value: identifier.value})
@@ -60,14 +57,7 @@ MERGE (s)- [:HARVESTED_FOR] - >(p)
 WITH DISTINCT s
 OPTIONAL MATCH (s)- [r:HAS_SUBJECT] - >(c:Concept)
 WHERE NOT c.uri IN $subject_uris
-OPTIONAL MATCH (c)- [:HAS_PREF_LABEL|:HAS_ALT_LABEL] - >(l:Literal)
 DELETE r
-WITH s, c, l
-WHERE NOT (c)- -(:SourceRecord)
-DETACH DELETE c
-WITH s, l
-WHERE NOT (l)- -(:Concept)
-DELETE l
 
 WITH DISTINCT s
 UNWIND $subject_uris AS subject_uri

--- a/tests/data/source_records/scanr_article_c_source_record.json
+++ b/tests/data/source_records/scanr_article_c_source_record.json
@@ -1,0 +1,109 @@
+{
+  "source_identifier": "doi10.1016/j.astron.2024.05.018",
+  "harvester": "ScanR",
+  "harvester_version": "1.2.0",
+  "identifiers": [
+    {
+      "type": "doi",
+      "value": "10.1016/j.astron.2024.05.018"
+    }
+  ],
+  "manifestations": [],
+  "titles": [
+    {
+      "value": "Tracing Dust Dynamics in Galactic Halos: Observational Constraints and Modeling Approaches",
+      "language": "en"
+    }
+  ],
+  "subtitles": [],
+  "abstracts": [],
+  "subjects": [
+    {
+      "uri": "http://www.idref.fr/027818055/id",
+      "dereferenced": true,
+      "pref_labels": [
+        {
+          "value": "Matière interstellaire",
+          "language": "fr"
+        }
+      ],
+      "alt_labels": [
+        {
+          "value": "Milieu interstellaire",
+          "language": null
+        }
+      ]
+    }
+  ],
+  "document_type": [
+    {
+      "uri": "http://purl.org/ontology/bibo/Article",
+      "label": "Article"
+    }
+  ],
+  "contributions": [
+    {
+      "rank": 0,
+      "contributor": {
+        "source": "scanr",
+        "source_identifier": null,
+        "name": "A. C. Smith",
+        "name_variants": []
+      },
+      "role": "https://id.loc.gov/vocabulary/relators/aut.html",
+      "affiliations": []
+    },
+    {
+      "rank": 2,
+      "contributor": {
+        "source": "scanr",
+        "source_identifier": null,
+        "name": "L. F. Johnson",
+        "name_variants": []
+      },
+      "role": "https://id.loc.gov/vocabulary/relators/aut.html",
+      "affiliations": []
+    },
+    {
+      "rank": 1,
+      "contributor": {
+        "source": "scanr",
+        "source_identifier": "idref075678345",
+        "name": "R. A. Garcia",
+        "name_variants": []
+      },
+      "role": "https://id.loc.gov/vocabulary/relators/aut.html",
+      "affiliations": []
+    }
+  ],
+  "issue": {
+    "source": "ScanR",
+    "source_identifier": "astronomy_and_astrophysics_scanr",
+    "titles": [],
+    "volume": "29",
+    "number": [
+      "5"
+    ],
+    "rights": null,
+    "date": "2024-05-15",
+    "journal": {
+      "source": "ScanR",
+      "source_identifier": "0004-6361-1432-0746-astronomy_and_astrophysics-ScanR",
+      "issn": [
+        "0004-6361",
+        "1432-0746"
+      ],
+      "eissn": [],
+      "issn_l": null,
+      "publisher": "European Southern Observatory",
+      "titles": [
+        "Astronomy and Astrophysics"
+      ]
+    }
+  },
+  "page": "230-245",
+  "book": null,
+  "issued": "2024-05-15 00:00:00",
+  "created": null,
+  "version": 0
+}

--- a/tests/data/source_records/scanr_article_c_v2_source_record.json
+++ b/tests/data/source_records/scanr_article_c_v2_source_record.json
@@ -1,0 +1,109 @@
+{
+  "source_identifier": "doi10.1016/j.astron.2024.05.018",
+  "harvester": "ScanR",
+  "harvester_version": "1.2.0",
+  "identifiers": [
+    {
+      "type": "doi",
+      "value": "10.1016/j.astron.2024.05.018"
+    }
+  ],
+  "manifestations": [],
+  "titles": [
+    {
+      "value": "Tracing Dust Dynamics in Galactic Halos: Observational Constraints and Modeling Approaches",
+      "language": "en"
+    }
+  ],
+  "subtitles": [],
+  "abstracts": [],
+  "subjects": [
+    {
+      "uri": "http://www.idref.fr/11111111111/id",
+      "dereferenced": true,
+      "pref_labels": [
+        {
+          "value": "Nouveau concept",
+          "language": "fr"
+        }
+      ],
+      "alt_labels": [
+        {
+          "value": "New concept",
+          "language": null
+        }
+      ]
+    }
+  ],
+  "document_type": [
+    {
+      "uri": "http://purl.org/ontology/bibo/Article",
+      "label": "Article"
+    }
+  ],
+  "contributions": [
+    {
+      "rank": 0,
+      "contributor": {
+        "source": "scanr",
+        "source_identifier": null,
+        "name": "A. C. Smith",
+        "name_variants": []
+      },
+      "role": "https://id.loc.gov/vocabulary/relators/aut.html",
+      "affiliations": []
+    },
+    {
+      "rank": 2,
+      "contributor": {
+        "source": "scanr",
+        "source_identifier": null,
+        "name": "L. F. Johnson",
+        "name_variants": []
+      },
+      "role": "https://id.loc.gov/vocabulary/relators/aut.html",
+      "affiliations": []
+    },
+    {
+      "rank": 1,
+      "contributor": {
+        "source": "scanr",
+        "source_identifier": "idref075678345",
+        "name": "R. A. Garcia",
+        "name_variants": []
+      },
+      "role": "https://id.loc.gov/vocabulary/relators/aut.html",
+      "affiliations": []
+    }
+  ],
+  "issue": {
+    "source": "ScanR",
+    "source_identifier": "astronomy_and_astrophysics_scanr",
+    "titles": [],
+    "volume": "29",
+    "number": [
+      "5"
+    ],
+    "rights": null,
+    "date": "2024-05-15",
+    "journal": {
+      "source": "ScanR",
+      "source_identifier": "0004-6361-1432-0746-astronomy_and_astrophysics-ScanR",
+      "issn": [
+        "0004-6361",
+        "1432-0746"
+      ],
+      "eissn": [],
+      "issn_l": null,
+      "publisher": "European Southern Observatory",
+      "titles": [
+        "Astronomy and Astrophysics"
+      ]
+    }
+  },
+  "page": "230-245",
+  "book": null,
+  "issued": "2024-05-15 00:00:00",
+  "created": null,
+  "version": 0
+}

--- a/tests/fixtures/source_record_fixtures.py
+++ b/tests/fixtures/source_record_fixtures.py
@@ -118,6 +118,59 @@ async def fixture_scanr_article_b_source_record_json_data(_base_path) -> dict:
     return _source_record_json_data_from_file(_base_path, "scanr_article_b_source_record")
 
 
+@pytest_asyncio.fixture(name="scanr_persisted_article_c_source_record_pydantic_model")
+async def fixture_scanr_persisted_article_c_source_record_pydantic_model(
+        scanr_article_c_source_record_pydantic_model: SourceRecord,
+        persisted_person_b_pydantic_model: Person
+) -> SourceRecord:
+    """
+    Persist a source record pydantic model from ScanR data
+    :return: persisted source record pydantic model from ScanR data
+    """
+    service = SourceRecordService()
+    await service.create_source_record(source_record=scanr_article_c_source_record_pydantic_model,
+                                       harvested_for=persisted_person_b_pydantic_model)
+    return await service.get_source_record(
+        scanr_article_c_source_record_pydantic_model.uid)
+
+
+@pytest_asyncio.fixture(name="scanr_article_c_source_record_pydantic_model")
+async def fixture_scanr_article_c_source_record_pydantic_model(
+        scanr_article_c_source_record_json_data) -> SourceRecord:
+    """
+    Create an article source record pydantic model from ScanR data
+    :return: basic source record pydantic model from ScanR data
+    """
+    return _source_record_from_json_data(scanr_article_c_source_record_json_data)
+
+
+@pytest_asyncio.fixture(name="scanr_article_c_source_record_json_data")
+async def fixture_scanr_article_c_source_record_json_data(_base_path) -> dict:
+    """
+    Create an article source record dict from ScanR data
+    :return: basic source record dict from ScanR data
+    """
+    return _source_record_json_data_from_file(_base_path, "scanr_article_c_source_record")
+
+
+@pytest_asyncio.fixture(name="scanr_article_c_v2_source_record_pydantic_model")
+async def fixture_scanr_article_c_v2_source_record_pydantic_model(
+        scanr_article_c_v2_source_record_json_data) -> SourceRecord:
+    """
+    Create an article source record pydantic model from ScanR data
+    :return: basic source record pydantic model from ScanR data
+    """
+    return _source_record_from_json_data(scanr_article_c_v2_source_record_json_data)
+
+
+@pytest_asyncio.fixture(name="scanr_article_c_v2_source_record_json_data")
+async def fixture_scanr_article_c_v2_source_record_json_data(_base_path) -> dict:
+    """
+    Create an article source record dict from ScanR data
+    :return: basic source record dict from ScanR data
+    """
+    return _source_record_json_data_from_file(_base_path, "scanr_article_c_v2_source_record")
+
 @pytest_asyncio.fixture(name="idref_thesis_source_record_pydantic_model")
 async def fixture_idref_thesis_source_record_pydantic_model(
         idref_thesis_source_record_json_data) -> SourceRecord:

--- a/tests/test_services/test_source_records_service_update.py
+++ b/tests/test_services/test_source_records_service_update.py
@@ -170,6 +170,6 @@ async def test_update_record_with_shared_concept(
 
     assert fetched_source_record_c.subjects != fetched_source_record_c_v2.subjects
     assert all(
-        concept in fetched_source_record_c_v2.subjects for concept in
-        scanr_article_c_v2_source_record_pydantic_model.subjects
+        concept.uri in map(lambda x: x.uri, fetched_source_record_c_v2.subjects)
+        for concept in scanr_article_c_v2_source_record_pydantic_model.subjects
     )

--- a/tests/test_services/test_source_records_service_update.py
+++ b/tests/test_services/test_source_records_service_update.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.models.identifier_types import PublicationIdentifierType
 from app.models.people import Person
 from app.models.source_records import SourceRecord
@@ -52,7 +54,6 @@ async def test_update_scanr_article_source_record(
         and identifier.type == PublicationIdentifierType.DOI
         for identifier in
         fetched_source_record.identifiers)
-
 
 
 async def test_double_update_scanr_article_source_record(
@@ -112,3 +113,63 @@ async def test_double_update_scanr_article_source_record(
 
     assert len(fetched_source_record_v3.abstracts) == len(
         scanr_article_a_v3_source_record_pydantic_model.abstracts)
+
+
+@pytest.mark.current
+async def test_update_record_with_shared_concept(
+        persisted_person_b_pydantic_model: Person,
+        scanr_persisted_article_a_source_record_pydantic_model: SourceRecord,
+        scanr_persisted_article_c_source_record_pydantic_model: SourceRecord,
+        scanr_article_c_v2_source_record_pydantic_model: SourceRecord
+):
+    """
+        Given two persisted source records with a shared concept
+        When the update of scanr article c remove the relation to the shared concept and add a
+        new concept
+        Then the values should be returned correctly for both source records
+    """
+    service = SourceRecordService()
+    shared_concept_uri = "http://www.idref.fr/027818055/id"
+
+    fetched_source_record_a = await service.get_source_record(
+        scanr_persisted_article_a_source_record_pydantic_model.uid)
+    assert all(
+        concept in fetched_source_record_a.subjects for concept in
+        scanr_persisted_article_a_source_record_pydantic_model.subjects
+    )
+
+    fetched_source_record_c = await service.get_source_record(
+        scanr_persisted_article_c_source_record_pydantic_model.uid)
+    assert all(
+        concept in fetched_source_record_c.subjects for concept in
+        scanr_persisted_article_c_source_record_pydantic_model.subjects
+    )
+    assert any(
+        shared_concept_uri == subject.uri for subject in fetched_source_record_a.subjects
+    )
+    assert any(
+        shared_concept_uri == subject.uri for subject in fetched_source_record_c.subjects
+    )
+
+    await service.update_source_record(
+        source_record=scanr_article_c_v2_source_record_pydantic_model,
+        harvested_for=persisted_person_b_pydantic_model)
+    fetched_source_record_c_v2 = await service.get_source_record(
+        scanr_article_c_v2_source_record_pydantic_model.uid)
+
+    post_update_fetched_source_record_a = await service.get_source_record(
+        scanr_persisted_article_a_source_record_pydantic_model.uid)
+    assert post_update_fetched_source_record_a == fetched_source_record_a
+    assert any(
+        shared_concept_uri == subject.uri for subject in
+        post_update_fetched_source_record_a.subjects
+    )
+    assert not any(
+        shared_concept_uri == subject.uri for subject in fetched_source_record_c_v2.subjects
+    )
+
+    assert fetched_source_record_c.subjects != fetched_source_record_c_v2.subjects
+    assert all(
+        concept in fetched_source_record_c_v2.subjects for concept in
+        scanr_article_c_v2_source_record_pydantic_model.subjects
+    )


### PR DESCRIPTION
from:
https://github.com/CRISalid-esr/crisalid-ikg/issues/135

Test:
https://github.com/CRISalid-esr/crisalid-ikg/blob/e9512e3c82eb8051f8a1f14c5e61522531dd4326/tests/test_services/test_source_records_service_update.py#L118-L175

When the scanr article c is updated, the relation to the concept shared with article a is removed as expected, but the concept newly added is created but the relation between the record and the concept does not exist