### PR TITLE
Handle inconsistent custom_metadata (not a dict)

### DIFF
--- a/app/graph/neo4j/source_record_dao.py
+++ b/app/graph/neo4j/source_record_dao.py
@@ -447,8 +447,8 @@ class SourceRecordDAO(Neo4jDAO):
                 source_record.issue = SourceIssue(**issue)
         if record["s"]["harvester"] == "HAL":
             source_record.custom_metadata = HalCustomMetadata(
-                hal_collection_codes=record["s"].get("hal_collection_codes", []),
-                hal_submit_type=record["s"].get("hal_submit_type", "")
+                hal_collection_codes=record["s"].get("hal_collection_codes", None),
+                hal_submit_type=record["s"].get("hal_submit_type", None)
             )
         contributions = record.get("contributions", [])
         SourceRecordDAO._hydrate_contributions(contributions, source_record)

--- a/app/models/source_records.py
+++ b/app/models/source_records.py
@@ -63,7 +63,11 @@ class SourceRecord(BaseModel):
     @classmethod
     def _convert_custom_metadata(cls, values):
         harvester = values.get("harvester")
-        metadata = values.get("custom_metadata", {}) or {}
+        metadata = values.get("custom_metadata")
+
+        if not isinstance(metadata, dict):
+            metadata = {}
+
         if harvester == "HAL":
             values["custom_metadata"] = HalCustomMetadata(**metadata)
         else:

--- a/tests/data/source_records/hal_article_source_record_with_inconsistent_custom_metadata.json
+++ b/tests/data/source_records/hal_article_source_record_with_inconsistent_custom_metadata.json
@@ -1,0 +1,278 @@
+{
+   "source_identifier": "hal-02732648",
+   "harvester": "HAL",
+   "harvester_version": "1.9.2",
+   "identifiers": [
+      {
+         "type": "hal",
+         "value": "hal-02732648"
+      },
+      {
+         "type": "doi",
+         "value": "https://doi.org/10.12345/bch.0000.00000"
+      }
+   ],
+   "manifestations": [
+      {
+         "page": "https://hal.science/hal-01732648v1",
+         "download_url": "https://hal.science/hal-01732648/document",
+         "additional_files": []
+      }
+   ],
+   "titles": [
+      {
+         "value": "Sample Title: Insights from oral conditions",
+         "language": "en"
+      }
+   ],
+   "subtitles": [],
+   "abstracts": [
+      {
+         "value": "This is an abstract of the article.",
+         "language": "en"
+      }
+   ],
+   "subjects": [],
+   "document_type": [
+      {
+         "uri": "http://purl.org/ontology/bibo/Article",
+         "label": "Article"
+      }
+   ],
+   "contributions": [
+      {
+         "rank": 0,
+         "contributor": {
+            "source": "hal",
+            "source_identifier": "18274",
+            "name": "Jane Doe",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "name_variants": [],
+            "structured_name_variants": [],
+            "identifiers": [
+               {
+                  "source": "hal",
+                  "type": "idref",
+                  "value": "https://www.idref.fr/179785966"
+               },
+               {
+                  "source": "hal",
+                  "type": "orcid",
+                  "value": "https://orcid.org/0000-0002-6180-194X"
+               },
+               {
+                  "source": "hal",
+                  "type": "idhal_s",
+                  "value": "jane-doe"
+               },
+               {
+                  "source": "hal",
+                  "type": "idhal_i",
+                  "value": "18274"
+               }
+            ]
+         },
+         "role": "https://id.loc.gov/vocabulary/relators/aut.html",
+         "affiliations": [
+            {
+               "source": "hal",
+               "source_identifier": "441569",
+               "name": "Centre National de la Recherche Scientifique",
+               "type": "institution_group",
+               "identifiers": [
+                  {
+                     "type": "hal",
+                     "value": "441569"
+                  },
+                  {
+                     "type": "isni",
+                     "value": "0000000122597504"
+                  },
+                  {
+                     "type": "idref",
+                     "value": "02636817X"
+                  },
+                  {
+                     "type": "ror",
+                     "value": "https://ror.org/02feahw73"
+                  }
+               ]
+            },
+            {
+               "source": "hal",
+               "source_identifier": "11141",
+               "name": "Université Paris 8 Vincennes-Saint-Denis",
+               "type": "institution",
+               "identifiers": [
+                  {
+                     "type": "hal",
+                     "value": "11141"
+                  },
+                  {
+                     "type": "isni",
+                     "value": "0000000121083026"
+                  },
+                  {
+                     "type": "idref",
+                     "value": "026403552"
+                  },
+                  {
+                     "type": "ror",
+                     "value": "https://ror.org/04wez5e68"
+                  }
+               ]
+            },
+            {
+               "source": "hal",
+               "source_identifier": "7550",
+               "name": "Université Paris 1 Panthéon-Sorbonne",
+               "type": "institution",
+               "identifiers": [
+                  {
+                     "type": "hal",
+                     "value": "7550"
+                  },
+                  {
+                     "type": "isni",
+                     "value": "000000012173743X"
+                  },
+                  {
+                     "type": "idref",
+                     "value": "027361802"
+                  },
+                  {
+                     "type": "ror",
+                     "value": "https://ror.org/002t25c44"
+                  }
+               ]
+            },
+            {
+               "source": "hal",
+               "source_identifier": "300125",
+               "name": "Ministère de la Culture et de la Communication",
+               "type": "institution_group",
+               "identifiers": [
+                  {
+                     "type": "hal",
+                     "value": "300125"
+                  },
+                  {
+                     "type": "idref",
+                     "value": "026437414"
+                  },
+                  {
+                     "type": "ror",
+                     "value": "https://ror.org/017rnyz40"
+                  }
+               ]
+            },
+            {
+               "source": "hal",
+               "source_identifier": "1003",
+               "name": "Archéologies et Sciences de l'Antiquité",
+               "type": "laboratory",
+               "identifiers": [
+                  {
+                     "type": "hal",
+                     "value": "1003"
+                  },
+                  {
+                     "type": "isni",
+                     "value": "0000 0001 2326 1930"
+                  },
+                  {
+                     "type": "rnsr",
+                     "value": "199912442H"
+                  },
+                  {
+                     "type": "idref",
+                     "value": "069431787"
+                  },
+                  {
+                     "type": "ror",
+                     "value": "https://ror.org/04wz9m339"
+                  }
+               ]
+            },
+            {
+               "source": "hal",
+               "source_identifier": "217516",
+               "name": "Trajectoires - UMR 8215",
+               "type": "laboratory",
+               "identifiers": [
+                  {
+                     "type": "hal",
+                     "value": "217516"
+                  },
+                  {
+                     "type": "rnsr",
+                     "value": "201220425D"
+                  },
+                  {
+                     "type": "idref",
+                     "value": "197718469"
+                  },
+                  {
+                     "type": "ror",
+                     "value": "https://ror.org/03wdx6c48"
+                  }
+               ]
+            },
+            {
+               "source": "hal",
+               "source_identifier": "116205",
+               "name": "Université Paris Nanterre",
+               "type": "institution",
+               "identifiers": [
+                  {
+                     "type": "hal",
+                     "value": "116205"
+                  },
+                  {
+                     "type": "idref",
+                     "value": "026403587"
+                  },
+                  {
+                     "type": "ror",
+                     "value": "https://ror.org/013bkhk48"
+                  }
+               ]
+            }
+         ]
+      }
+   ],
+   "issue": {
+      "source": "HAL",
+      "source_identifier": "journal-issue-identifier",
+      "titles": [],
+      "volume": "164",
+      "number": [
+         "4"
+      ],
+      "rights": null,
+      "date": null,
+      "journal": {
+         "source": "HAL",
+         "source_identifier": "2871",
+         "issn": [
+            "0002-9483"
+         ],
+         "eissn": [
+            "1096-8644"
+         ],
+         "issn_l": null,
+         "publisher": "Example Publisher",
+         "titles": [
+            "Sample Journal Title"
+         ]
+      }
+   },
+   "page": "702-719",
+   "book": null,
+   "raw_issued": "2017",
+   "issued": "2017-01-01T00:00:00Z",
+   "created": "2017-01-01T00:00:00",
+   "custom_metadata": "Inconsistent custom metadata",
+   "version": 3
+}

--- a/tests/fixtures/source_record_fixtures.py
+++ b/tests/fixtures/source_record_fixtures.py
@@ -706,6 +706,29 @@ async def fixture_hal_article_source_record_with_custom_metadata_v2_json_data(_b
     return _source_record_json_data_from_file(_base_path,
                                               "hal_article_source_record_with_custom_metadata_v2")
 
+@pytest_asyncio.fixture(name=\
+                       "hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model")
+async def fixture_hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model(
+        hal_article_source_record_with_inconsistent_custom_metadata_json_data) -> SourceRecord:
+    """
+    Create an article source record pydantic model from open_alex data
+    :return: basic source record pydantic model from open_alex data
+    """
+    return _source_record_from_json_data(
+        hal_article_source_record_with_inconsistent_custom_metadata_json_data)
+
+
+@pytest_asyncio.fixture(name=\
+                       "hal_article_source_record_with_inconsistent_custom_metadata_json_data")
+async def fixture_hal_article_source_record_with_inconsistent_custom_metadata_json_data(
+        _base_path) -> dict:
+    """
+    Create an article source record dict from open_alex data
+    :return: basic source record dict from open_alex data
+    """
+    return _source_record_json_data_from_file(_base_path,
+                                 "hal_article_source_record_with_inconsistent_custom_metadata")
+
 
 @pytest_asyncio.fixture(name="open_alex_article_with_journal_1_persisted_model")
 async def fixture_open_alex_article_with_journal_1_persisted_model(

--- a/tests/test_models/test_source_records.py
+++ b/tests/test_models/test_source_records.py
@@ -189,6 +189,68 @@ def test_create_article_source_record_from_hal_data(
     assert source_record.custom_metadata.hal_submit_type == "notice"
 
 
+def test_create_article_source_record_from_hal_inconsistent_data(
+        hal_article_source_record_with_inconsistent_custom_metadata_json_data: dict
+):
+    """
+    Given a source record model recording an article harvested from Hal
+    When asked for different field values
+    Then the values should be returned correctly
+    :param hal_article_source_record_with_custom_metadata_json_data:
+    :return:
+    """
+    source_record = SourceRecord(
+        **hal_article_source_record_with_inconsistent_custom_metadata_json_data)
+    assert source_record
+    assert source_record.harvester == "HAL"
+    assert source_record.source_identifier == "hal-02732648"
+    assert len(source_record.titles) == 1
+    assert len(source_record.identifiers) == 2
+    assert any(
+        title for title in source_record.titles if
+        title.value == "Sample Title: Insights from oral conditions"
+    )
+    assert any(
+        identifier for identifier in source_record.identifiers if
+        identifier.type == PublicationIdentifierType.DOI
+        and identifier.value == "https://doi.org/10.12345/bch.0000.00000"
+    )
+    assert any(
+        identifier for identifier in source_record.identifiers if
+        identifier.type == PublicationIdentifierType.HAL
+        and identifier.value == "hal-02732648"
+    )
+    assert len(source_record.abstracts) == 1
+    assert any(
+        abstract for abstract in source_record.abstracts if
+        abstract.value == "This is an abstract of the article."
+    )
+    assert len(source_record.subjects) == 0
+    assert len(source_record.document_type) == 1
+    assert DocumentTypeEnum.ARTICLE in source_record.document_type
+    assert len(source_record.contributions) == 1
+    assert any(
+        contribution for contribution in source_record.contributions if
+        contribution.rank == 0 and contribution.contributor.name == "Jane Doe"
+    )
+    assert source_record.issue
+    assert source_record.issue.source == "HAL"
+    assert source_record.issue.source_identifier == "journal-issue-identifier"
+    assert len(source_record.issue.titles) == 0
+    assert source_record.issue.volume == "164"
+    assert source_record.issue.number == ["4"]
+    assert source_record.issue.rights is None
+    assert source_record.issue.date is None
+    assert source_record.issue.journal.source == "HAL"
+    assert source_record.issue.journal.source_identifier == "2871"
+    assert source_record.issue.journal.publisher == "Example Publisher"
+    assert source_record.issue.journal.titles == ["Sample Journal Title"]
+    assert source_record.issued.isoformat() == "2017-01-01T00:00:00+00:00"
+    assert source_record.raw_issued == "2017"
+    assert source_record.custom_metadata.hal_collection_codes is None
+    assert source_record.custom_metadata.hal_submit_type is None
+
+
 async def test_create_article_source_record_from_open_alex_data(
         open_alex_article_source_record_json_data: dict
 ):

--- a/tests/test_services/test_source_records_service_create.py
+++ b/tests/test_services/test_source_records_service_create.py
@@ -109,6 +109,63 @@ async def test_create_hal_source_record_with_custom_metadata(
     assert persisted_person_a_pydantic_model.uid in fetched_source_record.harvested_for_uids
 
 
+async def test_create_hal_source_record_with_inconsistent_custom_metadata(
+        persisted_person_a_pydantic_model: Person,
+        hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model: SourceRecord
+) -> None:
+    """
+    Given a persisted person pydantic model and a non persisted source record pydantic model
+    When the source record is added to the graph
+    Then the source record can be read from the graph
+    :param persisted_person_a_pydantic_model:
+    :param hal_article_source_record_with_custom_metadata_pydantic_model:
+    :return:
+    """
+    service = SourceRecordService()
+    await service.create_source_record(
+        source_record=hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model,
+        harvested_for=persisted_person_a_pydantic_model)
+    assert await service.source_record_exists(
+        hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model.uid)
+    fetched_source_record = await service.get_source_record(
+        hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model.uid)
+    assert fetched_source_record.uid == \
+           hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model.uid
+    assert fetched_source_record.issued == \
+           hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model.issued
+    assert fetched_source_record.raw_issued == \
+           hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model.raw_issued
+    assert fetched_source_record.source_identifier == \
+           hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model. \
+               source_identifier
+    assert fetched_source_record.harvester == \
+           hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model.harvester
+    assert fetched_source_record.custom_metadata.hal_collection_codes == \
+           hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model. \
+               custom_metadata.hal_collection_codes
+    assert fetched_source_record.custom_metadata.hal_submit_type == \
+           hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model. \
+               custom_metadata.hal_submit_type
+    for title in hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model.titles:
+        assert any(
+            fetched_title.language == title.language and fetched_title.value == title.value for
+            fetched_title in fetched_source_record.titles)
+    for identifier in hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model. \
+            identifiers:
+        assert any(
+            fetched_identifier.type ==
+            identifier.type and fetched_identifier.value == identifier.value
+            for fetched_identifier in fetched_source_record.identifiers)
+    for abstract in hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model. \
+            abstracts:
+        assert any(
+            fetched_abstract.language == abstract.language
+            and fetched_abstract.value == abstract.value
+            for fetched_abstract in fetched_source_record.abstracts)
+
+    assert persisted_person_a_pydantic_model.uid in fetched_source_record.harvested_for_uids
+
+
 async def test_journal_from_scanr_article(
         scanr_article_a_source_record_pydantic_model: SourceRecord,
         persisted_person_a_pydantic_model: Person

--- a/tests/test_services/test_source_records_service_update.py
+++ b/tests/test_services/test_source_records_service_update.py
@@ -95,7 +95,7 @@ async def test_update_hal_article_source_record_with_custom_metadata(
     assert fetched_source_record.issued.isoformat() == "2017-01-01T00:00:00+00:00"
     assert (fetched_source_record.raw_issued ==
             hal_article_source_record_with_custom_metadata_v2_pydantic_model.raw_issued)
-    assert len(fetched_source_record.custom_metadata.hal_collection_codes) != \
+    assert fetched_source_record.custom_metadata.hal_collection_codes != \
            hal_persisted_article_source_record_pydantic_model.custom_metadata.hal_collection_codes
     assert fetched_source_record.custom_metadata.hal_submit_type == "file"
     assert fetched_source_record.custom_metadata.hal_submit_type != \


### PR DESCRIPTION
Small modification to handle a custom_metadata that is not at least an empt dict. Tests modified accordingly .