### PR TITLE
feat: Record identifier used to harvest a publication (#369)

### DIFF
--- a/app/amqp/amqp_reference_message_processor.py
+++ b/app/amqp/amqp_reference_message_processor.py
@@ -4,6 +4,8 @@ from app.amqp.amqp_message_processor import AMQPMessageProcessor
 from app.errors.conflict_error import ConflictError
 from app.errors.database_error import DatabaseError
 from app.errors.reference_owner_not_found_error import ReferenceOwnerNotFoundError
+from app.models.agent_identifiers import PersonIdentifier
+from app.models.identifier_types import PersonIdentifierType
 from app.models.people import Person
 from app.models.source_records import SourceRecord
 from app.services.source_records.source_record_service import SourceRecordService
@@ -23,10 +25,12 @@ class AMQReferenceMessageProcessor(AMQPMessageProcessor):
         logger.info(f"Processing message {json_payload}")
         self._check_keys(json_payload, {
             "reference_event": ["type", "enhanced", "reference"],
-            "entity": []
+            "entity": [],
+            "harvesting": ["identifier_used_type", "identifier_used_value"]
         })
         event_data = json_payload["reference_event"]
         person_data = json_payload["entity"]
+        harvesting_data = json_payload["harvesting"]
         raw_event_type: str = event_data["type"]
         enhanced: bool = event_data["enhanced"]
 
@@ -39,6 +43,17 @@ class AMQReferenceMessageProcessor(AMQPMessageProcessor):
         if effective_event_type not in self.settings.event_types_to_process:
             logger.info(f"Event type {effective_event_type} not in settings, skipping processing")
             return
+        identifier_used_type = PersonIdentifierType.from_str(
+            harvesting_data["identifier_used_type"])
+        if identifier_used_type is None:
+            logger.error(
+                f"Unknown identifier type '{harvesting_data['identifier_used_type']}'"
+                f" in harvesting field, aborting message processing")
+            return
+        identifier_used = PersonIdentifier(
+            type=identifier_used_type,
+            value=harvesting_data["identifier_used_value"]
+        )
         reference_data = event_data["reference"]
         try:
             person = Person(**person_data | {'display_name': person_data['name']})
@@ -52,27 +67,30 @@ class AMQReferenceMessageProcessor(AMQPMessageProcessor):
             logger.error(f"Error processing source record data {reference_data} : {e}")
             raise e
         if effective_event_type in ["created"]:
-            await self._create_source_record(source_record, person)
+            await self._create_source_record(source_record, person, identifier_used)
         elif effective_event_type in ["updated"]:
-            await self._update_source_record(source_record, person)
+            await self._update_source_record(source_record, person, identifier_used)
         elif effective_event_type in ["unchanged"]:
             logger.debug(f"Source record {source_record.uid} is unchanged (not enhanced), "
                          f"no action "
                         f"taken")
 
-    async def _create_source_record(self, source_record, person, first_attempt=True):
+    async def _create_source_record(self, source_record, person, identifier_used,
+                                    first_attempt=True):
         try:
             if await self.service.source_record_exists(source_record.uid):
                 logger.warning(f"Source record {source_record.uid} already exists in the database")
                 if first_attempt:
                     logger.warning("The system will try to update it")
-                    await self._update_source_record(source_record, person, first_attempt=False)
+                    await self._update_source_record(source_record, person, identifier_used,
+                                                     first_attempt=False)
                     return
                 logger.error(f"Aborting update attempt for {source_record.uid}"
                              f" after failed create attempt", exc_info=True)
                 return
             await self.service.create_source_record(source_record=source_record,
-                                                    harvested_for=person)
+                                                    harvested_for=person,
+                                                    identifier_used=identifier_used)
         except ReferenceOwnerNotFoundError as e:
             logger.error(
                 f"Reference owner {person} not found while trying to create source record"
@@ -87,16 +105,19 @@ class AMQReferenceMessageProcessor(AMQPMessageProcessor):
                 f"Database error while trying to create source record {source_record} : {e}")
             raise e
 
-    async def _update_source_record(self, source_record, person, first_attempt=True):
+    async def _update_source_record(self, source_record, person, identifier_used,
+                                    first_attempt=True):
         try:
             if await self.service.source_record_exists(source_record.uid):
                 await self.service.update_source_record(source_record=source_record,
-                                                        harvested_for=person)
+                                                        harvested_for=person,
+                                                        identifier_used=identifier_used)
             else:
                 logger.warning(f"Source record {source_record.uid} does not exist in the database")
                 if first_attempt:
                     logger.warning("The system will try to create it")
-                    await self._create_source_record(source_record, person, first_attempt=False)
+                    await self._create_source_record(source_record, person, identifier_used,
+                                                     first_attempt=False)
                 else:
                     logger.error(f"Aborting create attempt for {source_record.uid}"
                                  f" after failed update attempt", exc_info=True)

--- a/app/amqp/amqp_reference_message_processor.py
+++ b/app/amqp/amqp_reference_message_processor.py
@@ -30,30 +30,18 @@ class AMQReferenceMessageProcessor(AMQPMessageProcessor):
         })
         event_data = json_payload["reference_event"]
         person_data = json_payload["entity"]
-        harvesting_data = json_payload["harvesting"]
-        raw_event_type: str = event_data["type"]
-        enhanced: bool = event_data["enhanced"]
-
         effective_event_type = (
             "updated"
-            if raw_event_type == "unchanged" and enhanced
-            else raw_event_type
+            if event_data["type"] == "unchanged" and event_data["enhanced"]
+            else event_data["type"]
         )
         # If the event type is not in settings.event_types_to_process, we skip processing
         if effective_event_type not in self.settings.event_types_to_process:
             logger.info(f"Event type {effective_event_type} not in settings, skipping processing")
             return
-        identifier_used_type = PersonIdentifierType.from_str(
-            harvesting_data["identifier_used_type"])
-        if identifier_used_type is None:
-            logger.error(
-                f"Unknown identifier type '{harvesting_data['identifier_used_type']}'"
-                f" in harvesting field, aborting message processing")
+        identifier_used = self._parse_identifier_used(json_payload["harvesting"])
+        if identifier_used is None:
             return
-        identifier_used = PersonIdentifier(
-            type=identifier_used_type,
-            value=harvesting_data["identifier_used_value"]
-        )
         reference_data = event_data["reference"]
         try:
             person = Person(**person_data | {'display_name': person_data['name']})
@@ -74,6 +62,20 @@ class AMQReferenceMessageProcessor(AMQPMessageProcessor):
             logger.debug(f"Source record {source_record.uid} is unchanged (not enhanced), "
                          f"no action "
                         f"taken")
+
+    @staticmethod
+    def _parse_identifier_used(harvesting_data: dict) -> PersonIdentifier | None:
+        identifier_used_type = PersonIdentifierType.from_str(
+            harvesting_data["identifier_used_type"])
+        if identifier_used_type is None:
+            logger.error(
+                f"Unknown identifier type '{harvesting_data['identifier_used_type']}'"
+                f" in harvesting field, aborting message processing")
+            return None
+        return PersonIdentifier(
+            type=identifier_used_type,
+            value=harvesting_data["identifier_used_value"]
+        )
 
     async def _create_source_record(self, source_record, person, identifier_used,
                                     first_attempt=True):

--- a/app/graph/neo4j/queries/create_source_record.cypher
+++ b/app/graph/neo4j/queries/create_source_record.cypher
@@ -52,7 +52,9 @@ MERGE (i)- [:ISSUED_BY] - >(j)
 )
 WITH s, $person_uid AS person_uid
 MATCH (p:Person {uid:person_uid})
-MERGE (s)- [:HARVESTED_FOR] - >(p)
+MERGE (s)- [r:HARVESTED_FOR] - >(p)
+SET r.identifier_used_type = $identifier_used_type,
+    r.identifier_used_value = $identifier_used_value
 
 WITH s, $subject_uids AS subject_uids
 UNWIND subject_uids AS subject_uid

--- a/app/graph/neo4j/queries/get_source_record_uids_by_identifier_used.cypher
+++ b/app/graph/neo4j/queries/get_source_record_uids_by_identifier_used.cypher
@@ -1,0 +1,4 @@
+MATCH (s:SourceRecord)-[r:HARVESTED_FOR]->(p:Person {uid: $person_uid})
+WHERE r.identifier_used_type = $identifier_used_type
+  AND r.identifier_used_value = $identifier_used_value
+RETURN collect(s.uid) AS source_record_uids

--- a/app/graph/neo4j/queries/update_source_record.cypher
+++ b/app/graph/neo4j/queries/update_source_record.cypher
@@ -73,7 +73,9 @@ MERGE (i)- [:ISSUED_BY] - >(j)
 
 WITH DISTINCT s
 MATCH (p:Person {uid:$person_uid})
-MERGE (s)- [:HARVESTED_FOR] - >(p)
+MERGE (s)- [r:HARVESTED_FOR] - >(p)
+SET r.identifier_used_type = $identifier_used_type,
+    r.identifier_used_value = $identifier_used_value
 
 WITH DISTINCT s
 OPTIONAL MATCH (s)- [r:HAS_SUBJECT] - >(c:Concept)

--- a/app/graph/neo4j/queries/update_source_record.cypher
+++ b/app/graph/neo4j/queries/update_source_record.cypher
@@ -29,11 +29,11 @@ OPTIONAL MATCH (s)-[r:HAS_ABSTRACT]->(:TextLiteral {type: 'source_record_abstrac
 DELETE r
 WITH DISTINCT s
 FOREACH (abstract IN $abstracts |
-  MERGE (a:TextLiteral {key: abstract.key, type:'source_record_abstract'})
-  ON CREATE SET
-    a.value    = abstract.value,
+  MERGE (a:TextLiteral {key: abstract.key, type: 'source_record_abstract'})
+    ON CREATE SET
+    a.value = abstract.value,
     a.language = coalesce(nullif(trim(abstract.language), ''), 'und'),
-    a.type     = 'source_record_abstract'
+    a.type = 'source_record_abstract'
   MERGE (s)-[:HAS_ABSTRACT]->(a)
 )
 
@@ -50,9 +50,6 @@ FOREACH (identifier IN $identifiers |
 WITH s
 OPTIONAL MATCH (s)-[p:PUBLISHED_IN]->(i:SourceIssue)
 DELETE p
-WITH s, i
-  WHERE NOT (i)--(:SourceRecord)
-DETACH DELETE i
 
 WITH DISTINCT s
 FOREACH (_ IN CASE WHEN $issue IS NOT NULL THEN [1]
@@ -74,8 +71,8 @@ MERGE (i)- [:ISSUED_BY] - >(j)
 WITH DISTINCT s
 MATCH (p:Person {uid:$person_uid})
 MERGE (s)- [r:HARVESTED_FOR] - >(p)
-SET r.identifier_used_type = $identifier_used_type,
-    r.identifier_used_value = $identifier_used_value
+ON MATCH SET r.identifier_used_type = $identifier_used_type, r.identifier_used_value = $identifier_used_value
+ON CREATE SET r.identifier_used_type = $identifier_used_type, r.identifier_used_value = $identifier_used_value
 
 WITH DISTINCT s
 OPTIONAL MATCH (s)- [r:HAS_SUBJECT] - >(c:Concept)

--- a/app/graph/neo4j/source_record_dao.py
+++ b/app/graph/neo4j/source_record_dao.py
@@ -8,10 +8,12 @@ from app.errors.database_error import handle_database_errors
 from app.graph.neo4j.neo4j_connexion import Neo4jConnexion
 from app.graph.neo4j.neo4j_dao import Neo4jDAO
 from app.graph.neo4j.utils import load_query
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.concepts import Concept
 from app.models.document_type import DocumentTypeEnum
 from app.models.hal_custom_metadata import HalCustomMetadata
 from app.models.harvesters import Harvester
+from app.models.identifier_types import PersonIdentifierType
 from app.models.journal_identifiers import JournalIdentifier
 from app.models.literal import Literal
 from app.models.loc_contribution_role import LocContributionRole
@@ -52,7 +54,8 @@ class SourceRecordDAO(Neo4jDAO):
 
     @handle_database_errors
     async def create(self, source_record: SourceRecord,
-                     harvested_for: Person
+                     harvested_for: Person,
+                     identifier_used: PersonIdentifier
                      ) -> Tuple[
         str, Neo4jDAO.Status, UpdateStatus | None]:
         """
@@ -60,19 +63,22 @@ class SourceRecordDAO(Neo4jDAO):
 
         :param harvested_for: person on behalf of whom the source record was harvested
         :param source_record: source record object
+        :param identifier_used: person identifier that triggered the harvest
         :return: source record uid, operation status and update status details
         """
         async with Neo4jConnexion().get_driver() as driver:
             async with driver.session() as session:
                 await session.write_transaction(self._create_source_record_transaction,
                                                 source_record,
-                                                harvested_for
+                                                harvested_for,
+                                                identifier_used
                                                 )
         return source_record.uid, SourceRecordDAO.Status.CREATED, None
 
     @handle_database_errors
     async def update(self, source_record: SourceRecord,
-                     harvested_for: Person
+                     harvested_for: Person,
+                     identifier_used: PersonIdentifier
                      ) -> Tuple[
         str, Neo4jDAO.Status, UpdateStatus | None]:
         """
@@ -80,13 +86,15 @@ class SourceRecordDAO(Neo4jDAO):
 
         :param harvested_for: person on behalf of whom the source record was harvested
         :param source_record: source record object
+        :param identifier_used: person identifier that triggered the harvest
         :return: source record uid, operation status and update status details
         """
         async with Neo4jConnexion().get_driver() as driver:
             async with driver.session() as session:
                 async with await session.begin_transaction() as tx:
                     return await self._update_source_record_transaction(tx, source_record,
-                                                                        harvested_for)
+                                                                        harvested_for,
+                                                                        identifier_used)
 
     @handle_database_errors
     async def get_source_records_with_shared_identifier_uids(self, source_record_id: str):
@@ -133,6 +141,31 @@ class SourceRecordDAO(Neo4jDAO):
                 )
                 record = await result.single()
                 return record['source_record_uids']
+
+    @handle_database_errors
+    async def get_source_record_uids_by_identifier_used(
+            self,
+            person_uid: str,
+            identifier_used_type: PersonIdentifierType,
+            identifier_used_value: str
+    ) -> List[str]:
+        """
+        Get source record UIDs harvested for a person using a specific identifier
+        :param person_uid: person uid
+        :param identifier_used_type: type of the identifier used to trigger the harvest
+        :param identifier_used_value: value of the identifier used to trigger the harvest
+        :return: list of source record UIDs
+        """
+        async with Neo4jConnexion().get_driver() as driver:
+            async with driver.session() as session:
+                result = await session.run(
+                    load_query("get_source_record_uids_by_identifier_used"),
+                    person_uid=person_uid,
+                    identifier_used_type=identifier_used_type.value,
+                    identifier_used_value=identifier_used_value
+                )
+                record = await result.single()
+                return record['source_record_uids'] if record else []
 
     @handle_database_errors
     async def delete_inferred_equivalence_relationships(self, source_record_uid: str,
@@ -293,7 +326,8 @@ class SourceRecordDAO(Neo4jDAO):
     @classmethod
     async def _create_source_record_transaction(cls, tx: AsyncManagedTransaction,
                                                 source_record: SourceRecord,
-                                                harvested_for: Person
+                                                harvested_for: Person,
+                                                identifier_used: PersonIdentifier
                                                 ):
         if not source_record.uid:
             raise ValueError(f"Unable to compute primary key for source record {source_record}")
@@ -316,6 +350,8 @@ class SourceRecordDAO(Neo4jDAO):
             source_identifier=source_record.source_identifier,
             harvester=source_record.harvester.value,
             person_uid=harvested_for.uid,
+            identifier_used_type=identifier_used.type.value,
+            identifier_used_value=identifier_used.value,
             issue=issue,
             journal_uid=source_record.issue.journal.uid if source_record.issue and
                                                            source_record.issue.journal else None,
@@ -341,7 +377,8 @@ class SourceRecordDAO(Neo4jDAO):
     @classmethod
     async def _update_source_record_transaction(cls, tx: AsyncManagedTransaction,
                                                 source_record: SourceRecord,
-                                                harvested_for: Person
+                                                harvested_for: Person,
+                                                identifier_used: PersonIdentifier
                                                 ) -> Tuple[
         str, Neo4jDAO.Status, UpdateStatus | None]:
         if not source_record.uid:
@@ -364,6 +401,8 @@ class SourceRecordDAO(Neo4jDAO):
             source_identifier=source_record.source_identifier,
             harvester=source_record.harvester.value,
             person_uid=harvested_for.uid,
+            identifier_used_type=identifier_used.type.value,
+            identifier_used_value=identifier_used.value,
             issue=issue,
             journal_uid=source_record.issue.journal.uid if source_record.issue and
                                                            source_record.issue.journal else None,

--- a/app/routes/source_records.py
+++ b/app/routes/source_records.py
@@ -6,6 +6,7 @@ from fastapi.encoders import jsonable_encoder
 from starlette import status
 from starlette.responses import JSONResponse
 
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.people import Person
 from app.models.source_records import SourceRecord
 from app.services.source_records.source_record_service import SourceRecordService
@@ -28,6 +29,7 @@ async def create_source_record(
         source_record_service: Annotated[SourceRecordService, Depends(SourceRecordService)],
         source_record: SourceRecord,
         person: Person,
+        identifier_used: PersonIdentifier,
 ) -> JSONResponse:
     """
     Creates a source record and attaches it to the person for whom it was harvested
@@ -35,12 +37,14 @@ async def create_source_record(
     :param source_record_service: service to handle CRUD operations on source records
     :param source_record: entity built from fields
     :param person: entity built from fields
+    :param identifier_used: person identifier that triggered the harvest
     :return: json response
     """
 
     created_source_record = await source_record_service.create_source_record(
         source_record=source_record,
-        harvested_for=person)
+        harvested_for=person,
+        identifier_used=identifier_used)
 
     response_data = {"message": "Source record created successfully", "source_record":
         created_source_record}

--- a/app/services/source_records/source_record_service.py
+++ b/app/services/source_records/source_record_service.py
@@ -8,6 +8,7 @@ from app.graph.generic.dao_factory import DAOFactory
 from app.graph.neo4j.neo4j_dao import Neo4jDAO
 from app.graph.neo4j.person_dao import PersonDAO
 from app.graph.neo4j.source_record_dao import SourceRecordDAO
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.people import Person
 from app.models.source_records import SourceRecord
 from app.services.concepts.concept_service import ConceptService
@@ -23,13 +24,15 @@ class SourceRecordService:
     """
 
     async def create_source_record(self, source_record: SourceRecord,
-                                   harvested_for: Person) -> SourceRecord:
+                                   harvested_for: Person,
+                                   identifier_used: PersonIdentifier) -> SourceRecord:
         """
         Create a source bibliographic record in the graph database
         from a Pydantic SourceRecord object and a Pydantic Person object
         :param source_record: Pydantic SourceRecord object
         :param harvested_for: Pydantic Person object.
                 The person the reference has been harvested for
+        :param identifier_used: person identifier that triggered the harvest
         :return:
         """
         person = await self._handle_source_record_owner(harvested_for)
@@ -37,20 +40,22 @@ class SourceRecordService:
         await self._handle_source_record_affiliations(source_record)
         await self._handle_source_record_subjects(source_record)
         await self._handle_source_record_journal(source_record)
-        status = await self._create_source_record(source_record, person)
+        status = await self._create_source_record(source_record, person, identifier_used)
         await self._update_source_record_contributions(source_record)
         if status == Neo4jDAO.Status.CREATED:
             await source_record_created.send_async(self, source_record_id=source_record.uid)
         return source_record
 
     async def update_source_record(self, source_record: SourceRecord,
-                                   harvested_for: Person) -> SourceRecord:
+                                   harvested_for: Person,
+                                   identifier_used: PersonIdentifier) -> SourceRecord:
         """
         Update a source bibliographic record in the graph database
         from a Pydantic SourceRecord object and a Pydantic Person object
         :param source_record: Pydantic SourceRecord object
         :param harvested_for: Pydantic Person object.
                The person the reference has been harvested for
+        :param identifier_used: person identifier that triggered the harvest
         :return:
         """
         person = await self._handle_source_record_owner(harvested_for)
@@ -58,16 +63,18 @@ class SourceRecordService:
         await self._handle_source_record_affiliations(source_record)
         await self._handle_source_record_subjects(source_record)
         await self._handle_source_record_journal(source_record)
-        status = await self._update_source_record(source_record, person)
+        status = await self._update_source_record(source_record, person, identifier_used)
         await self._update_source_record_contributions(source_record)
         if status == Neo4jDAO.Status.UPDATED:
             await source_record_updated.send_async(self, source_record_id=source_record.uid)
         return source_record
 
-    async def _create_source_record(self, source_record, person) -> Neo4jDAO.Status:
+    async def _create_source_record(self, source_record, person,
+                                    identifier_used: PersonIdentifier) -> Neo4jDAO.Status:
         source_record_dao: SourceRecordDAO = self._get_dao_factory().get_dao(SourceRecord)
         _, status, _ = await source_record_dao.create(source_record=source_record,
-                                                                     harvested_for=person)
+                                                      harvested_for=person,
+                                                      identifier_used=identifier_used)
         return status
 
     async def _update_source_record_contributions(self, source_record):
@@ -82,11 +89,13 @@ class SourceRecordService:
             except DatabaseError as e:
                 logger.error(f"Database error while creating contribution {contribution} : {e}")
 
-    async def _update_source_record(self, source_record, person) -> Neo4jDAO.Status:
+    async def _update_source_record(self, source_record, person,
+                                    identifier_used: PersonIdentifier) -> Neo4jDAO.Status:
         source_record_dao: SourceRecordDAO = self._get_dao_factory().get_dao(SourceRecord)
         _, status, _ = await source_record_dao.update(
             source_record=source_record,
-            harvested_for=person
+            harvested_for=person,
+            identifier_used=identifier_used
         )
         return status
 

--- a/tests/fixtures/source_record_fixtures.py
+++ b/tests/fixtures/source_record_fixtures.py
@@ -1,10 +1,20 @@
 import pytest_asyncio
 
+from app.models.agent_identifiers import PersonIdentifier
+from app.models.identifier_types import PersonIdentifierType
 from app.models.people import Person
 from app.models.source_records import SourceRecord
 from app.services.source_records.source_record_service import SourceRecordService
 from tests.fixtures.common import _source_record_from_json_data, \
     _source_record_json_data_from_file
+
+
+@pytest_asyncio.fixture(name="default_identifier_used")
+async def fixture_default_identifier_used() -> PersonIdentifier:
+    """
+    Default person identifier used to harvest a source record in test fixtures
+    """
+    return PersonIdentifier(type=PersonIdentifierType.IDREF, value="122758765")
 
 
 @pytest_asyncio.fixture(name="scanr_thesis_source_record_pydantic_model")
@@ -48,7 +58,8 @@ async def fixture_hal_chapter_a_v2_source_record_json_data(_base_path) -> dict:
 @pytest_asyncio.fixture(name="hal_chapter_a_source_record_persisted_model")
 async def fixture_hal_chapter_a_source_record_persisted_model(
         hal_chapter_a_source_record_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ) -> SourceRecord:
     """
     Persist a source record pydantic model from hal data
@@ -57,7 +68,8 @@ async def fixture_hal_chapter_a_source_record_persisted_model(
     service = SourceRecordService()
     await service.create_source_record(
         source_record=hal_chapter_a_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used
     )
     return await service.get_source_record(
         hal_chapter_a_source_record_pydantic_model.uid)
@@ -85,7 +97,8 @@ async def fixture_hal_chapter_a_source_record_json_data(_base_path) -> dict:
 @pytest_asyncio.fixture(name="scanr_article_a_source_record_persisted_model")
 async def fixture_scanr_article_a_source_record_persisted_model(
         scanr_article_a_source_record_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ) -> SourceRecord:
     """
     Persist a source record pydantic model from ScanR data
@@ -93,7 +106,8 @@ async def fixture_scanr_article_a_source_record_persisted_model(
     """
     service = SourceRecordService()
     await service.create_source_record(source_record=scanr_article_a_source_record_pydantic_model,
-                                       harvested_for=persisted_person_a_pydantic_model)
+                                       harvested_for=persisted_person_a_pydantic_model,
+                                       identifier_used=default_identifier_used)
     return await service.get_source_record(
         scanr_article_a_source_record_pydantic_model.uid)
 
@@ -142,7 +156,8 @@ async def fixture_scanr_article_a_source_record_with_updated_issue_json_data(_ba
 @pytest_asyncio.fixture(name="scanr_article_a_v2_source_record_persisted_model")
 async def fixture_scanr_article_a_v2_source_record_persisted_model(
         scanr_article_a_v2_source_record_pydantic_model: SourceRecord,
-        persisted_person_b_pydantic_model: Person
+        persisted_person_b_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ) -> SourceRecord:
     """
     Persist a source record pydantic model from ScanR data
@@ -151,7 +166,8 @@ async def fixture_scanr_article_a_v2_source_record_persisted_model(
     service = SourceRecordService()
     await service.create_source_record(
         source_record=scanr_article_a_v2_source_record_pydantic_model,
-        harvested_for=persisted_person_b_pydantic_model)
+        harvested_for=persisted_person_b_pydantic_model,
+        identifier_used=default_identifier_used)
     return await service.get_source_record(
         scanr_article_a_v2_source_record_pydantic_model.uid)
 
@@ -282,7 +298,8 @@ async def fixture_scanr_article_b_source_record_json_data(_base_path) -> dict:
 @pytest_asyncio.fixture(name="scanr_article_c_source_record_persisted_model")
 async def fixture_scanr_article_c_source_record_persisted_model(
         scanr_article_c_source_record_pydantic_model: SourceRecord,
-        persisted_person_b_pydantic_model: Person
+        persisted_person_b_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ) -> SourceRecord:
     """
     Persist a source record pydantic model from ScanR data
@@ -290,7 +307,8 @@ async def fixture_scanr_article_c_source_record_persisted_model(
     """
     service = SourceRecordService()
     await service.create_source_record(source_record=scanr_article_c_source_record_pydantic_model,
-                                       harvested_for=persisted_person_b_pydantic_model)
+                                       harvested_for=persisted_person_b_pydantic_model,
+                                       identifier_used=default_identifier_used)
     return await service.get_source_record(
         scanr_article_c_source_record_pydantic_model.uid)
 
@@ -528,7 +546,8 @@ async def fixture_source_record_with_unknown_source_json_data(_base_path) -> dic
 @pytest_asyncio.fixture(name="hal_article_a_source_record_persisted_model")
 async def fixture_hal_article_a_source_record_persisted_model(
         hal_article_a_source_record_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ) -> SourceRecord:
     """
     Persist a source record pydantic model from hal data
@@ -536,7 +555,8 @@ async def fixture_hal_article_a_source_record_persisted_model(
     """
     service = SourceRecordService()
     await service.create_source_record(source_record=hal_article_a_source_record_pydantic_model,
-                                       harvested_for=persisted_person_a_pydantic_model)
+                                       harvested_for=persisted_person_a_pydantic_model,
+                                       identifier_used=default_identifier_used)
     return await service.get_source_record(
         hal_article_a_source_record_pydantic_model.uid)
 
@@ -563,7 +583,8 @@ async def fixture_hal_article_a_source_record_json_data(_base_path) -> dict:
 @pytest_asyncio.fixture(name="open_alex_article_a_source_record_persisted_model")
 async def fixture_open_alex_article_a_source_record_persisted_model(
         open_alex_article_a_source_record_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ) -> SourceRecord:
     """
     Persist a source record pydantic model from open_alex data
@@ -572,7 +593,8 @@ async def fixture_open_alex_article_a_source_record_persisted_model(
     service = SourceRecordService()
     await service.create_source_record(
         source_record=open_alex_article_a_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used
     )
     return await service.get_source_record(
         open_alex_article_a_source_record_pydantic_model.uid)
@@ -600,7 +622,8 @@ async def fixture_open_alex_article_a_source_record_json_data(_base_path) -> dic
 @pytest_asyncio.fixture(name="open_alex_article_b_source_record_persisted_model")
 async def fixture_open_alex_article_b_source_record_persisted_model(
         open_alex_article_b_source_record_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ) -> SourceRecord:
     """
     Persist a source record pydantic model from open_alex data
@@ -609,7 +632,8 @@ async def fixture_open_alex_article_b_source_record_persisted_model(
     service = SourceRecordService()
     await service.create_source_record(
         source_record=open_alex_article_b_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used
     )
     return await service.get_source_record(
         open_alex_article_b_source_record_pydantic_model.uid)
@@ -636,7 +660,8 @@ async def fixture_open_alex_article_b_source_record_json_data(_base_path) -> dic
 @pytest_asyncio.fixture(name="idref_article_a_source_record_persisted_model")
 async def fixture_idref_article_a_source_record_persisted_model(
         idref_article_a_source_record_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ) -> SourceRecord:
     """
     Persist a source record pydantic model from open_alex data
@@ -645,7 +670,8 @@ async def fixture_idref_article_a_source_record_persisted_model(
     service = SourceRecordService()
     await service.create_source_record(
         source_record=idref_article_a_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used
     )
     return await service.get_source_record(
         idref_article_a_source_record_pydantic_model.uid)
@@ -673,7 +699,8 @@ async def fixture_idref_article_a_source_record_json_data(_base_path) -> dict:
 @pytest_asyncio.fixture(name="hal_article_source_record_persisted_model")
 async def fixture_hal_persisted_article_source_record_with_custom_metadata_pydantic_model(
         hal_article_source_record_with_custom_metadata_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ) -> SourceRecord:
     """
     Persist a source record pydantic model from ScanR data
@@ -682,7 +709,8 @@ async def fixture_hal_persisted_article_source_record_with_custom_metadata_pydan
     service = SourceRecordService()
     await service.create_source_record(
         source_record=hal_article_source_record_with_custom_metadata_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     return await service.get_source_record(
         hal_article_source_record_with_custom_metadata_pydantic_model.uid)
 
@@ -756,17 +784,20 @@ async def fixture_hal_article_source_record_with_inconsistent_custom_metadata_js
 @pytest_asyncio.fixture(name="open_alex_article_with_journal_1_persisted_model")
 async def fixture_open_alex_article_with_journal_1_persisted_model(
         open_alex_article_with_journal_1_pydantic_model: SourceRecord,
-        persisted_person_f_pydantic_model: Person) -> SourceRecord:
+        persisted_person_f_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier) -> SourceRecord:
     """
     Persist a source record pydantic model from OpenAlex data with journal 1 information
     :param open_alex_article_with_journal_1_pydantic_model:
     :param persisted_person_f_pydantic_model:
+    :param default_identifier_used:
     :return:
     """
     service = SourceRecordService()
     await service.create_source_record(
         source_record=open_alex_article_with_journal_1_pydantic_model,
-        harvested_for=persisted_person_f_pydantic_model
+        harvested_for=persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     return await service.get_source_record(
         open_alex_article_with_journal_1_pydantic_model.uid)
@@ -796,17 +827,20 @@ async def fixture_open_alex_article_with_journal_1_json_data(_base_path) -> dict
 @pytest_asyncio.fixture(name="open_alex_article_with_journal_2_persisted_model")
 async def fixture_open_alex_article_with_journal_2_persisted_model(
         open_alex_article_with_journal_2_pydantic_model: SourceRecord,
-        persisted_person_f_pydantic_model: Person) -> SourceRecord:
+        persisted_person_f_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier) -> SourceRecord:
     """
     Persist a source record pydantic model from OpenAlex data with journal 2 information
     :param open_alex_article_with_journal_2_pydantic_model:
     :param persisted_person_f_pydantic_model:
+    :param default_identifier_used:
     :return:
     """
     service = SourceRecordService()
     await service.create_source_record(
         source_record=open_alex_article_with_journal_2_pydantic_model,
-        harvested_for=persisted_person_f_pydantic_model
+        harvested_for=persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     return await service.get_source_record(
         open_alex_article_with_journal_2_pydantic_model.uid)
@@ -836,17 +870,20 @@ async def fixture_open_alex_article_with_journal_2_json_data(_base_path) -> dict
 @pytest_asyncio.fixture(name="hal_article_with_journal_1_persisted_model")
 async def fixture_hal_article_with_journal_1_persisted_model(
         hal_article_with_journal_1_pydantic_model: SourceRecord,
-        persisted_person_f_pydantic_model: Person) -> SourceRecord:
+        persisted_person_f_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier) -> SourceRecord:
     """
     Persist a source record pydantic model from HAL data with journal 1 information
     :param hal_article_with_journal_1_pydantic_model:
     :param persisted_person_f_pydantic_model:
+    :param default_identifier_used:
     :return:
     """
     service = SourceRecordService()
     await service.create_source_record(
         source_record=hal_article_with_journal_1_pydantic_model,
-        harvested_for=persisted_person_f_pydantic_model
+        harvested_for=persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     return await service.get_source_record(
         hal_article_with_journal_1_pydantic_model.uid)
@@ -897,17 +934,20 @@ async def fixture_hal_article_with_journal_2_json_data(_base_path) -> dict:
 @pytest_asyncio.fixture(name="hal_article_with_inconsistent_journal_1_persisted_model")
 async def fixture_hal_article_with_inconsistent_journal_1_persisted_model(
         hal_article_with_inconsistent_journal_1_pydantic_model: SourceRecord,
-        persisted_person_f_pydantic_model: Person) -> SourceRecord:
+        persisted_person_f_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier) -> SourceRecord:
     """
     Persist a source record pydantic model from HAL data with inconsistent journal 1 information
     :param hal_article_with_inconsistent_journal_1_pydantic_model:
     :param persisted_person_f_pydantic_model:
+    :param default_identifier_used:
     :return:
     """
     service = SourceRecordService()
     await service.create_source_record(
         source_record=hal_article_with_inconsistent_journal_1_pydantic_model,
-        harvested_for=persisted_person_f_pydantic_model
+        harvested_for=persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     return await service.get_source_record(
         hal_article_with_inconsistent_journal_1_pydantic_model.uid)

--- a/tests/fixtures/source_record_id_fixtures.py
+++ b/tests/fixtures/source_record_id_fixtures.py
@@ -1,6 +1,7 @@
 import pytest_asyncio
 
 from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.document import Document
 from app.models.people import Person
 from app.models.source_records import SourceRecord
@@ -77,13 +78,15 @@ async def fixture_source_record_id_hal_1_pydantic_model(
 @pytest_asyncio.fixture(name="source_record_id_doi_1_persisted_model")
 async def fixture_source_record_id_doi_1_persisted_model(
         source_record_id_doi_1_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person) -> SourceRecord:
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier) -> SourceRecord:
     """
     Persist source record Pydantic model for source_record_id_doi_1
     """
     service = SourceRecordService()
     await service.create_source_record(source_record=source_record_id_doi_1_pydantic_model,
-                                       harvested_for=persisted_person_a_pydantic_model)
+                                       harvested_for=persisted_person_a_pydantic_model,
+                                       identifier_used=default_identifier_used)
     return await service.get_source_record(source_record_id_doi_1_pydantic_model.uid)
 
 
@@ -101,24 +104,28 @@ async def fixture_document_persisted_model(
 @pytest_asyncio.fixture(name="source_record_id_doi_1_hal_1_persisted_model")
 async def fixture_source_record_id_doi_1_hal_1_persisted_model(
         source_record_id_doi_1_hal_1_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person) -> SourceRecord:
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier) -> SourceRecord:
     """
     Persist source record Pydantic model for source_record_id_doi_1_hal_1
     """
     service = SourceRecordService()
     await service.create_source_record(source_record=source_record_id_doi_1_hal_1_pydantic_model,
-                                       harvested_for=persisted_person_a_pydantic_model)
+                                       harvested_for=persisted_person_a_pydantic_model,
+                                       identifier_used=default_identifier_used)
     return await service.get_source_record(source_record_id_doi_1_hal_1_pydantic_model.uid)
 
 
 @pytest_asyncio.fixture(name="source_record_id_hal_1_persisted_model")
 async def fixture_source_record_id_hal_1_persisted_model(
         source_record_id_hal_1_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person) -> SourceRecord:
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier) -> SourceRecord:
     """
     Persist source record Pydantic model for source_record_id_hal_1
     """
     service = SourceRecordService()
     await service.create_source_record(source_record=source_record_id_hal_1_pydantic_model,
-                                       harvested_for=persisted_person_a_pydantic_model)
+                                       harvested_for=persisted_person_a_pydantic_model,
+                                       identifier_used=default_identifier_used)
     return await service.get_source_record(source_record_id_hal_1_pydantic_model.uid)

--- a/tests/test_routes/test_source_records.py
+++ b/tests/test_routes/test_source_records.py
@@ -22,7 +22,8 @@ def test_create_source_records_success(
     """
     model = {
         "source_record": idref_record_with_person_a_as_contributor_json_data,
-        "person": raw_person_a_json_data
+        "person": raw_person_a_json_data,
+        "identifier_used": {"type": "idref", "value": "122758765"}
     }
     response = test_client.post(API_SOURCE_RECORDS_PATH, json=model)
     assert response.status_code == status.HTTP_201_CREATED
@@ -48,7 +49,8 @@ def test_create_source_records_for_unknown_person(
     """
     model = {
         "source_record": idref_record_with_person_a_as_contributor_json_data,
-        "person": raw_person_a_json_data
+        "person": raw_person_a_json_data,
+        "identifier_used": {"type": "idref", "value": "122758765"}
     }
     response = test_client.post(API_SOURCE_RECORDS_PATH,
                                 json=model)
@@ -75,7 +77,8 @@ def test_create_source_record_with_invalid_record_data(
     idref_record_with_person_a_as_contributor_json_data["titles"] = []
     model = {
         "source_record": idref_record_with_person_a_as_contributor_json_data,
-        "person": raw_person_a_json_data
+        "person": raw_person_a_json_data,
+        "identifier_used": {"type": "idref", "value": "122758765"}
     }
 
     response = test_client.post(API_SOURCE_RECORDS_PATH,
@@ -124,7 +127,8 @@ def test_create_source_record_twice(
     """
     model = {
         "source_record": idref_record_with_person_a_as_contributor_json_data,
-        "person": raw_person_a_json_data
+        "person": raw_person_a_json_data,
+        "identifier_used": {"type": "idref", "value": "122758765"}
     }
 
     response = test_client.post(API_SOURCE_RECORDS_PATH, json=model)

--- a/tests/test_search/test_source_records_index.py
+++ b/tests/test_search/test_source_records_index.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.people import Person
 from app.models.source_records import SourceRecord
 from app.search.source_record_index import SourceRecordIndex
@@ -19,7 +20,8 @@ async def test_signal_source_record_created(
         test_app,  # pylint: disable=unused-argument
         persisted_person_a_pydantic_model: Person,
         scanr_thesis_source_record_pydantic_model: SourceRecord,
-        mock_source_record_index_add_source_record: mock.MagicMock):
+        mock_source_record_index_add_source_record: mock.MagicMock,
+        default_identifier_used: PersonIdentifier):
     """
     Given a new source record Pydantic model
     When the source record is added to the graph
@@ -29,7 +31,8 @@ async def test_signal_source_record_created(
     service = SourceRecordService()
     await service.create_source_record(
         source_record=scanr_thesis_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used
     )
     mock_source_record_index_add_source_record.assert_called_once_with(
         service,

--- a/tests/test_services/test_document_service.py
+++ b/tests/test_services/test_document_service.py
@@ -4,6 +4,7 @@ from typing import cast
 from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
 from app.graph.neo4j.document_dao import DocumentDAO
 from app.graph.neo4j.source_record_dao import SourceRecordDAO
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.document import Document
 from app.models.identifier_types import PublicationIdentifierType
 from app.models.journal_article import JournalArticle
@@ -108,6 +109,7 @@ async def test_oa_status_document_with_no_doi_and_no_hal(
         hal_article_with_journal_1_pydantic_model: SourceRecord,
         open_alex_article_with_journal_1_pydantic_model: SourceRecord,
         persisted_person_f_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier,
 ) -> None:
     """
     Test that when a journal is created from source records with no doi and no file in hal,
@@ -131,11 +133,13 @@ async def test_oa_status_document_with_no_doi_and_no_hal(
     hal_article_with_journal_1_persisted_model = await (
         source_record_service.create_source_record(
             hal_article_with_journal_1_pydantic_model,
-            persisted_person_f_pydantic_model
+            persisted_person_f_pydantic_model,
+            identifier_used=default_identifier_used
         ))
     await source_record_service.create_source_record(
         open_alex_article_with_journal_1_pydantic_model,
-        persisted_person_f_pydantic_model
+        persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     factory = AbstractDAOFactory().get_dao_factory("neo4j")
     document_dao: DocumentDAO = cast(DocumentDAO, factory.get_dao(Document))
@@ -164,6 +168,7 @@ async def test_oa_status_document_with_no_doi_but_hal(
         hal_article_with_journal_1_pydantic_model: SourceRecord,
         open_alex_article_with_journal_1_pydantic_model: SourceRecord,
         persisted_person_f_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier,
 ) -> None:
     """
     Test that when a journal is created from source records with no doi but a file in hal,
@@ -190,11 +195,13 @@ async def test_oa_status_document_with_no_doi_but_hal(
     hal_article_with_journal_1_persisted_model = await (
         source_record_service.create_source_record(
             hal_article_with_journal_1_pydantic_model,
-            persisted_person_f_pydantic_model
+            persisted_person_f_pydantic_model,
+            identifier_used=default_identifier_used
         ))
     await source_record_service.create_source_record(
         open_alex_article_with_journal_1_pydantic_model,
-        persisted_person_f_pydantic_model
+        persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     factory = AbstractDAOFactory().get_dao_factory("neo4j")
     document_dao: DocumentDAO = cast(DocumentDAO, factory.get_dao(Document))
@@ -224,6 +231,7 @@ async def test_oa_status_document_with_doi_but_no_hal(
         hal_article_with_journal_1_pydantic_model: SourceRecord,
         open_alex_article_with_journal_1_pydantic_model: SourceRecord,
         persisted_person_f_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier,
 ) -> None:
     """
     Test that when a journal is created from source records with no doi and no file in
@@ -247,11 +255,13 @@ async def test_oa_status_document_with_doi_but_no_hal(
     hal_article_with_journal_1_persisted_model = await (
         source_record_service.create_source_record(
             hal_article_with_journal_1_pydantic_model,
-            persisted_person_f_pydantic_model
+            persisted_person_f_pydantic_model,
+            identifier_used=default_identifier_used
         ))
     await source_record_service.create_source_record(
         open_alex_article_with_journal_1_pydantic_model,
-        persisted_person_f_pydantic_model
+        persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     factory = AbstractDAOFactory().get_dao_factory("neo4j")
     document_dao: DocumentDAO = cast(DocumentDAO, factory.get_dao(Document))
@@ -281,6 +291,7 @@ async def test_oa_status_document_with_doi_not_in_upw_and_no_hal(
         hal_article_with_journal_1_pydantic_model: SourceRecord,
         open_alex_article_with_journal_1_pydantic_model: SourceRecord,
         persisted_person_f_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier,
 ) -> None:
     """
     Test that when a journal is created from source records with no file in hal and the doi
@@ -304,11 +315,13 @@ async def test_oa_status_document_with_doi_not_in_upw_and_no_hal(
     hal_article_with_journal_1_persisted_model = await (
         source_record_service.create_source_record(
             hal_article_with_journal_1_pydantic_model,
-            persisted_person_f_pydantic_model
+            persisted_person_f_pydantic_model,
+            identifier_used=default_identifier_used
         ))
     await source_record_service.create_source_record(
         open_alex_article_with_journal_1_pydantic_model,
-        persisted_person_f_pydantic_model
+        persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     factory = AbstractDAOFactory().get_dao_factory("neo4j")
     document_dao: DocumentDAO = cast(DocumentDAO, factory.get_dao(Document))

--- a/tests/test_services/test_document_service_with_journals.py
+++ b/tests/test_services/test_document_service_with_journals.py
@@ -4,6 +4,7 @@ import pytest
 
 from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
 from app.graph.neo4j.document_dao import DocumentDAO
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.document import Document
 from app.models.document_publication_channel import DocumentPublicationChannel
 from app.models.journal import Journal
@@ -49,6 +50,7 @@ async def test_merge_documents_with_journal_information(
         hal_article_with_journal_1_pydantic_model: SourceRecord,
         open_alex_article_with_journal_1_pydantic_model: SourceRecord,
         persisted_person_f_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier,
 ) -> None:
     """
     Test that when 2 equivalent source records come with journal issn pointing to the same journal,
@@ -62,11 +64,13 @@ async def test_merge_documents_with_journal_information(
     hal_article_with_journal_1_persisted_model = await (
         source_record_service.create_source_record(
             hal_article_with_journal_1_pydantic_model,
-            persisted_person_f_pydantic_model
+            persisted_person_f_pydantic_model,
+            identifier_used=default_identifier_used
         ))
     await source_record_service.create_source_record(
         open_alex_article_with_journal_1_pydantic_model,
-        persisted_person_f_pydantic_model
+        persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     factory = AbstractDAOFactory().get_dao_factory("neo4j")
     document_dao: DocumentDAO = cast(DocumentDAO, factory.get_dao(Document))
@@ -102,6 +106,7 @@ async def test_merge_documents_with_inconsistent_journal_information(
         hal_article_with_inconsistent_journal_1_pydantic_model: SourceRecord,
         open_alex_article_with_journal_1_pydantic_model: SourceRecord,
         persisted_person_f_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier,
 ) -> None:
     """
     Test that when 2 equivalent source records with journal information come but the first one (
@@ -116,11 +121,13 @@ async def test_merge_documents_with_inconsistent_journal_information(
     hal_article_with_inconsistent_journal_1_persisted_model = await (
         source_record_service.create_source_record(
             hal_article_with_inconsistent_journal_1_pydantic_model,
-            persisted_person_f_pydantic_model
+            persisted_person_f_pydantic_model,
+            identifier_used=default_identifier_used
         ))
     await source_record_service.create_source_record(
         open_alex_article_with_journal_1_pydantic_model,
-        persisted_person_f_pydantic_model
+        persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     factory = AbstractDAOFactory().get_dao_factory("neo4j")
     document_dao: DocumentDAO = cast(DocumentDAO, factory.get_dao(Document))
@@ -157,6 +164,7 @@ async def test_merge_documents_with_different_journal_information(
         hal_article_with_journal_1_pydantic_model: SourceRecord,
         open_alex_article_with_journal_2_pydantic_model: SourceRecord,
         persisted_person_f_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier,
 ) -> None:
     """
     Test that when 2 equivalent source records with journal information come but the first one (
@@ -171,11 +179,13 @@ async def test_merge_documents_with_different_journal_information(
     hal_article_with_journal_1_persisted_model = await (
         source_record_service.create_source_record(
             hal_article_with_journal_1_pydantic_model,
-            persisted_person_f_pydantic_model
+            persisted_person_f_pydantic_model,
+            identifier_used=default_identifier_used
         ))
     await source_record_service.create_source_record(
         open_alex_article_with_journal_2_pydantic_model,
-        persisted_person_f_pydantic_model
+        persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     factory = AbstractDAOFactory().get_dao_factory("neo4j")
     document_dao: DocumentDAO = cast(DocumentDAO, factory.get_dao(Document))
@@ -209,7 +219,8 @@ async def test_merge_documents_with_journal_information_changes(
         hal_article_with_journal_1_pydantic_model: SourceRecord,
         hal_article_with_journal_2_pydantic_model: SourceRecord,
         persisted_person_f_pydantic_model: Person,
-        open_alex_article_with_journal_1_pydantic_model: SourceRecord
+        open_alex_article_with_journal_1_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier,
 ) -> None:
     """
     Test that when a document is updated with a new journal information,
@@ -227,11 +238,13 @@ async def test_merge_documents_with_journal_information_changes(
     hal_article_with_journal_1_persisted_model = await (
         source_record_service.create_source_record(
             hal_article_with_journal_1_pydantic_model,
-            persisted_person_f_pydantic_model
+            persisted_person_f_pydantic_model,
+            identifier_used=default_identifier_used
         ))
     await source_record_service.create_source_record(
         open_alex_article_with_journal_1_pydantic_model,
-        persisted_person_f_pydantic_model
+        persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
 
     factory = AbstractDAOFactory().get_dao_factory("neo4j")
@@ -263,7 +276,8 @@ async def test_merge_documents_with_journal_information_changes(
     assert journal.publisher == "American Society of Civil Engineers v2"
     await source_record_service.update_source_record(
         hal_article_with_journal_2_pydantic_model,
-        persisted_person_f_pydantic_model
+        persisted_person_f_pydantic_model,
+        identifier_used=default_identifier_used
     )
     await document_service.update_from_source_records(
         None,

--- a/tests/test_services/test_equivalence_service.py
+++ b/tests/test_services/test_equivalence_service.py
@@ -4,6 +4,7 @@ from typing import cast
 from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
 from app.graph.neo4j.document_dao import DocumentDAO
 from app.graph.neo4j.source_record_dao import SourceRecordDAO
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.document import Document
 from app.models.journal_article import JournalArticle
 from app.models.people import Person
@@ -58,7 +59,8 @@ async def test_attach_new_source_record_to_existing_document(
         test_app,  # pylint: disable=unused-argument
         source_record_id_doi_1_persisted_model: SourceRecord,
         source_record_id_doi_1_hal_1_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Test that the equivalence service can infer equivalent source records
@@ -76,7 +78,8 @@ async def test_attach_new_source_record_to_existing_document(
         source_record_id_doi_1_persisted_model.uid, SourceRecordDAO.EquivalenceType.INFERRED)
     assert len(equivalent_uids) == 0
     await source_record_service.create_source_record(source_record_id_doi_1_hal_1_pydantic_model,
-                                                     persisted_person_a_pydantic_model)
+                                                     persisted_person_a_pydantic_model,
+                                                     default_identifier_used)
     # equivalence service will not be called automatically as blinker signals are not connected
     await equivalence_service.update_source_record(None, source_record_id_doi_1_persisted_model.uid)
     equivalent_uids = await source_record_dao.get_source_records_equivalent_uids(
@@ -107,7 +110,8 @@ async def test_merge_two_existing_documents(
         source_record_id_doi_1_persisted_model: SourceRecord,
         source_record_id_hal_1_persisted_model: SourceRecord,
         source_record_id_doi_1_hal_1_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Test that the equivalence service can infer equivalent source records
@@ -131,7 +135,8 @@ async def test_merge_two_existing_documents(
     assert len(equivalent_uids_2) == 0
     # create a new source record with the same identifiers as the two existing ones
     await source_record_service.create_source_record(source_record_id_doi_1_hal_1_pydantic_model,
-                                                     persisted_person_a_pydantic_model)
+                                                     persisted_person_a_pydantic_model,
+                                                     default_identifier_used)
     # equivalence service will not be called automatically as blinker signals are not connected
     await equivalence_service.update_source_record(None, source_record_id_doi_1_persisted_model.uid)
     equivalent_uids_1 = await source_record_dao.get_source_records_equivalent_uids(

--- a/tests/test_services/test_source_contributors_equivalence_service.py
+++ b/tests/test_services/test_source_contributors_equivalence_service.py
@@ -5,6 +5,7 @@ from app.graph.neo4j.document_dao import DocumentDAO
 from app.graph.neo4j.person_dao import PersonDAO
 from app.graph.neo4j.source_person_dao import SourcePersonDAO
 from app.graph.neo4j.source_record_dao import SourceRecordDAO
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.document import Document
 from app.models.people import Person
 from app.models.source_people import SourcePerson
@@ -20,7 +21,8 @@ async def test_create_source_records_with_shared_contributors(
         persisted_person_e_pydantic_model: Person,
         scanr_article_a_v2_source_record_pydantic_model: SourceRecord,
         hal_article_a_source_record_pydantic_model: SourceRecord,
-        open_alex_article_a_source_record_pydantic_model: SourceRecord
+        open_alex_article_a_source_record_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given 3 source records with common hal identifier and created for different persons,
@@ -32,15 +34,18 @@ async def test_create_source_records_with_shared_contributors(
     source_record_service = SourceRecordService()
     await source_record_service.create_source_record(
         source_record=hal_article_a_source_record_pydantic_model,
-        harvested_for=persisted_person_e_pydantic_model)
+        harvested_for=persisted_person_e_pydantic_model,
+        identifier_used=default_identifier_used)
 
     await source_record_service.create_source_record(
         source_record=scanr_article_a_v2_source_record_pydantic_model,
-        harvested_for=persisted_person_d_pydantic_model)
+        harvested_for=persisted_person_d_pydantic_model,
+        identifier_used=default_identifier_used)
 
     await source_record_service.create_source_record(
         source_record=open_alex_article_a_source_record_pydantic_model,
-        harvested_for=persisted_person_d_pydantic_model)
+        harvested_for=persisted_person_d_pydantic_model,
+        identifier_used=default_identifier_used)
     factory = AbstractDAOFactory().get_dao_factory("neo4j")
     document_dao: DocumentDAO = cast(DocumentDAO, factory.get_dao(Document))
     document = await document_dao.get_document_by_source_record_uid(
@@ -85,7 +90,8 @@ async def test_create_source_records_with_shared_contributors(
             )
     await source_record_service.update_source_record(
         source_record=hal_article_a_source_record_pydantic_model,
-        harvested_for=persisted_person_e_pydantic_model)
+        harvested_for=persisted_person_e_pydantic_model,
+        identifier_used=default_identifier_used)
     document = await document_dao.get_document_by_source_record_uid(
         hal_article_a_source_record_pydantic_model.uid)
     assert document is not None
@@ -98,6 +104,7 @@ async def test_two_equivalent_records_with_the_same_contributors(
         persisted_person_a_pydantic_model: Person,
         article_exoplanet_from_oa_source_record_pydantic_model: SourceRecord,
         article_exoplanet_from_scanr_source_record_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given two source records with the same 3 contributors from 2 different source platforms,
@@ -116,11 +123,13 @@ async def test_two_equivalent_records_with_the_same_contributors(
     source_record_service = SourceRecordService()
     await source_record_service.create_source_record(
         source_record=article_exoplanet_from_oa_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
 
     await source_record_service.create_source_record(
         source_record=article_exoplanet_from_scanr_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
 
     factory = AbstractDAOFactory().get_dao_factory("neo4j")
     document_dao: DocumentDAO = cast(DocumentDAO, factory.get_dao(Document))

--- a/tests/test_services/test_source_records_and_concepts_services.py
+++ b/tests/test_services/test_source_records_and_concepts_services.py
@@ -1,3 +1,4 @@
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.people import Person
 from app.models.source_records import SourceRecord
 from app.services.concepts.concept_service import ConceptService
@@ -6,7 +7,8 @@ from app.services.source_records.source_record_service import SourceRecordServic
 
 async def test_create_source_records_with_a_unreferenced_concept(
         persisted_person_b_pydantic_model: Person,
-        scanr_record_with_person_b_as_contributor_pydantic_model: SourceRecord
+        scanr_record_with_person_b_as_contributor_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given a persisted person pydantic_model,
@@ -23,7 +25,8 @@ async def test_create_source_records_with_a_unreferenced_concept(
 
     await record_service.create_source_record(
         source_record=scanr_record_with_person_b_as_contributor_pydantic_model,
-        harvested_for=persisted_person_b_pydantic_model)
+        harvested_for=persisted_person_b_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_scanr_source_record_for_person_b = await record_service.get_source_record(
         scanr_record_with_person_b_as_contributor_pydantic_model.uid)
     assert (
@@ -38,7 +41,8 @@ async def test_create_two_source_records_with_same_concepts(
         persisted_person_a_pydantic_model: Person,
         persisted_person_b_pydantic_model: Person,
         scanr_record_with_person_a_as_contributor_pydantic_model: SourceRecord,
-        scanr_record_with_person_b_as_contributor_pydantic_model: SourceRecord
+        scanr_record_with_person_b_as_contributor_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given two persisted person pydantic_model,
@@ -58,7 +62,8 @@ async def test_create_two_source_records_with_same_concepts(
 
     await record_service.create_source_record(
         source_record=scanr_record_with_person_a_as_contributor_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_scanr_source_record_for_person_a = await record_service.get_source_record(
         scanr_record_with_person_a_as_contributor_pydantic_model.uid)
     assert (
@@ -72,7 +77,8 @@ async def test_create_two_source_records_with_same_concepts(
                fetched_concept.pref_labels)
     await record_service.create_source_record(
         source_record=scanr_record_with_person_b_as_contributor_pydantic_model,
-        harvested_for=persisted_person_b_pydantic_model)
+        harvested_for=persisted_person_b_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_scanr_source_record_for_person_b = await record_service.get_source_record(
         scanr_record_with_person_b_as_contributor_pydantic_model.uid)
     assert (
@@ -90,7 +96,8 @@ async def test_create_two_source_records_with_common_concepts_and_different_alt_
         persisted_person_a_pydantic_model: Person,
         scanr_record_with_person_a_as_contrib_and_additional_alt_labels_pyd_model: SourceRecord,
         persisted_person_b_pydantic_model: Person,
-        scanr_record_with_person_b_as_contributor_pydantic_model: SourceRecord
+        scanr_record_with_person_b_as_contributor_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given two persisted person pydantic_model,
@@ -124,7 +131,8 @@ async def test_create_two_source_records_with_common_concepts_and_different_alt_
 
     await record_service.create_source_record(
         source_record=scanr_record_with_person_a_as_contrib_and_additional_alt_labels_pyd_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_scanr_source_record_for_person_a = await record_service.get_source_record(
         scanr_record_with_person_a_as_contrib_and_additional_alt_labels_pyd_model.uid)
     assert (
@@ -141,7 +149,8 @@ async def test_create_two_source_records_with_common_concepts_and_different_alt_
 
     await record_service.create_source_record(
         source_record=scanr_record_with_person_b_as_contributor_pydantic_model,
-        harvested_for=persisted_person_b_pydantic_model)
+        harvested_for=persisted_person_b_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_scanr_source_record_for_person_b = await record_service.get_source_record(
         scanr_record_with_person_b_as_contributor_pydantic_model.uid)
     assert (

--- a/tests/test_services/test_source_records_and_equivalence_service.py
+++ b/tests/test_services/test_source_records_and_equivalence_service.py
@@ -2,6 +2,7 @@ from typing import cast
 
 from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
 from app.graph.neo4j.document_dao import DocumentDAO
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.document import Document
 from app.models.identifier_types import PublicationIdentifierType
 from app.models.people import Person
@@ -16,7 +17,8 @@ async def test_create_multiple_source_records_with_common_id_for_multiple_person
         persisted_person_b_pydantic_model: Person,
         scanr_article_a_v2_source_record_pydantic_model: SourceRecord,
         hal_article_a_source_record_pydantic_model: SourceRecord,
-        open_alex_article_a_source_record_pydantic_model: SourceRecord
+        open_alex_article_a_source_record_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given 3 source records with common hal identifier and created for different persons,
@@ -26,15 +28,18 @@ async def test_create_multiple_source_records_with_common_id_for_multiple_person
     source_record_service = SourceRecordService()
     await source_record_service.create_source_record(
         source_record=hal_article_a_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
 
     await source_record_service.create_source_record(
         source_record=scanr_article_a_v2_source_record_pydantic_model,
-        harvested_for=persisted_person_b_pydantic_model)
+        harvested_for=persisted_person_b_pydantic_model,
+        identifier_used=default_identifier_used)
 
     await source_record_service.create_source_record(
         source_record=open_alex_article_a_source_record_pydantic_model,
-        harvested_for=persisted_person_b_pydantic_model)
+        harvested_for=persisted_person_b_pydantic_model,
+        identifier_used=default_identifier_used)
 
     hal_fetched_source_record = await source_record_service.get_source_record(
         hal_article_a_source_record_pydantic_model.uid
@@ -76,7 +81,8 @@ async def test_update_one_source_record_between_multiple_related_source_records(
         hal_article_a_source_record_persisted_model: SourceRecord,
         open_alex_article_a_source_record_persisted_model: SourceRecord,
         scanr_article_a_v2_source_record_persisted_model: SourceRecord,
-        scanr_article_a_v2_source_record_without_hal_doi_identifiers_pydantic_model: SourceRecord
+        scanr_article_a_v2_source_record_without_hal_doi_identifiers_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given 3 persisted source records with common hal identifier and a Document in common
@@ -99,7 +105,8 @@ async def test_update_one_source_record_between_multiple_related_source_records(
 
     await source_record_service.update_source_record(
         source_record=scanr_article_a_v2_source_record_without_hal_doi_identifiers_pydantic_model,
-        harvested_for=persisted_person_b_pydantic_model)
+        harvested_for=persisted_person_b_pydantic_model,
+        identifier_used=default_identifier_used)
     updated_fetched_source_record = await source_record_service.get_source_record(
         scanr_article_a_v2_source_record_without_hal_doi_identifiers_pydantic_model.uid)
     assert updated_fetched_source_record
@@ -128,6 +135,7 @@ async def test_create_source_records_with_one_having_common_id_with_others(
         scanr_article_a_source_record_pydantic_model: SourceRecord,
         open_alex_article_b_source_record_pydantic_model: SourceRecord,
         idref_article_a_source_record_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given 3 source records harvested, with one of them having common identifiers with the other two,
@@ -143,7 +151,8 @@ async def test_create_source_records_with_one_having_common_id_with_others(
     ]:
         await source_record_service.create_source_record(
             source_record=record,
-            harvested_for=persisted_person_a_pydantic_model)
+            harvested_for=persisted_person_a_pydantic_model,
+            identifier_used=default_identifier_used)
 
         assert await source_record_service.get_source_record(record.uid)
 
@@ -165,6 +174,7 @@ async def test_create_source_record_with_common_id_with_persisted_source_records
         scanr_article_a_source_record_persisted_model: SourceRecord,
         idref_article_a_source_record_persisted_model: SourceRecord,
         open_alex_article_b_source_record_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given 2 persisted source record with no identifiers in common,
@@ -184,7 +194,8 @@ async def test_create_source_record_with_common_id_with_persisted_source_records
 
     await source_record_service.create_source_record(
         source_record=open_alex_article_b_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
 
     document_after_update = await document_dao.get_document_by_source_record_uid(
         open_alex_article_b_source_record_pydantic_model.uid

--- a/tests/test_services/test_source_records_service_contributions_create.py
+++ b/tests/test_services/test_source_records_service_contributions_create.py
@@ -1,4 +1,5 @@
 # pylint: disable=duplicate-code
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.harvesting_sources import HarvestingSource
 from app.models.loc_contribution_role import LocContributionRole
 from app.models.people import Person
@@ -10,7 +11,8 @@ from app.services.source_records.source_record_service import SourceRecordServic
 async def test_create_source_record_with_contributions(
         test_app,  # pylint: disable=unused-argument
         persisted_person_a_pydantic_model: Person,
-        hal_chapter_a_source_record_pydantic_model: SourceRecord
+        hal_chapter_a_source_record_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given a persisted person pydantic model and a non persisted source record pydantic model
@@ -23,7 +25,8 @@ async def test_create_source_record_with_contributions(
     """
     service = SourceRecordService()
     await service.create_source_record(source_record=hal_chapter_a_source_record_pydantic_model,
-                                       harvested_for=persisted_person_a_pydantic_model)
+                                       harvested_for=persisted_person_a_pydantic_model,
+                                       identifier_used=default_identifier_used)
     assert await service.source_record_exists(hal_chapter_a_source_record_pydantic_model.uid)
     fetched_source_record = await service.get_source_record(
         hal_chapter_a_source_record_pydantic_model.uid)

--- a/tests/test_services/test_source_records_service_contributions_update.py
+++ b/tests/test_services/test_source_records_service_contributions_update.py
@@ -1,3 +1,4 @@
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.harvesting_sources import HarvestingSource
 from app.models.loc_contribution_role import LocContributionRole
 from app.models.people import Person
@@ -9,7 +10,8 @@ async def test_create_source_record_with_contributions(
         # test_app,  # pylint: disable=unused-argument
         persisted_person_a_pydantic_model: Person,
         hal_chapter_a_source_record_persisted_model: SourceRecord,
-        hal_chapter_a_v2_source_record_pydantic_model: SourceRecord
+        hal_chapter_a_v2_source_record_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given a persisted person pydantic model and a persisted source record pydantic model
@@ -27,7 +29,8 @@ async def test_create_source_record_with_contributions(
     assert fetched_source_record
     await service.update_source_record(
         source_record=hal_chapter_a_v2_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_source_record_v2 = await service.get_source_record(
         hal_chapter_a_v2_source_record_pydantic_model.uid)
     assert fetched_source_record_v2

--- a/tests/test_services/test_source_records_service_create.py
+++ b/tests/test_services/test_source_records_service_create.py
@@ -1,8 +1,11 @@
-from typing import List
+from typing import List, cast
 
+from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
+from app.graph.neo4j.source_record_dao import SourceRecordDAO
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.harvesters import Harvester
 from app.models.harvesting_sources import HarvestingSource
-from app.models.identifier_types import JournalIdentifierType
+from app.models.identifier_types import JournalIdentifierType, PersonIdentifierType
 from app.models.journal_identifiers import JournalIdentifier
 from app.models.people import Person
 from app.models.source_records import SourceRecord
@@ -10,7 +13,8 @@ from app.services.source_records.source_record_service import SourceRecordServic
 
 
 async def test_create_source_record(persisted_person_a_pydantic_model: Person,
-                                    scanr_thesis_source_record_pydantic_model: SourceRecord
+                                    scanr_thesis_source_record_pydantic_model: SourceRecord,
+                                    default_identifier_used: PersonIdentifier
                                     ) -> None:
     """
     Given a persisted person pydantic model and a non persisted source record pydantic model
@@ -22,7 +26,8 @@ async def test_create_source_record(persisted_person_a_pydantic_model: Person,
     """
     service = SourceRecordService()
     await service.create_source_record(source_record=scanr_thesis_source_record_pydantic_model,
-                                       harvested_for=persisted_person_a_pydantic_model)
+                                       harvested_for=persisted_person_a_pydantic_model,
+                                       identifier_used=default_identifier_used)
     assert await service.source_record_exists(scanr_thesis_source_record_pydantic_model.uid)
     fetched_source_record = await service.get_source_record(
         scanr_thesis_source_record_pydantic_model.uid)
@@ -59,7 +64,8 @@ async def test_create_source_record(persisted_person_a_pydantic_model: Person,
 
 async def test_create_hal_source_record_with_custom_metadata(
         persisted_person_a_pydantic_model: Person,
-        hal_article_source_record_with_custom_metadata_pydantic_model: SourceRecord
+        hal_article_source_record_with_custom_metadata_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given a persisted person pydantic model and a non persisted source record pydantic model
@@ -72,7 +78,8 @@ async def test_create_hal_source_record_with_custom_metadata(
     service = SourceRecordService()
     await service.create_source_record(
         source_record=hal_article_source_record_with_custom_metadata_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     assert await service.source_record_exists(
         hal_article_source_record_with_custom_metadata_pydantic_model.uid)
     fetched_source_record = await service.get_source_record(
@@ -113,7 +120,8 @@ async def test_create_hal_source_record_with_custom_metadata(
 
 async def test_create_hal_source_record_with_inconsistent_custom_metadata(
         persisted_person_a_pydantic_model: Person,
-        hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model: SourceRecord
+        hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given a persisted person pydantic model and a non persisted source record pydantic model
@@ -126,7 +134,8 @@ async def test_create_hal_source_record_with_inconsistent_custom_metadata(
     service = SourceRecordService()
     await service.create_source_record(
         source_record=hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     assert await service.source_record_exists(
         hal_article_source_record_with_inconsistent_custom_metadata_pydantic_model.uid)
     fetched_source_record = await service.get_source_record(
@@ -170,7 +179,8 @@ async def test_create_hal_source_record_with_inconsistent_custom_metadata(
 
 async def test_journal_from_scanr_article(
         scanr_article_a_source_record_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ):
     """
         Given a valid source record model recording an article harvested from ScanR
@@ -179,7 +189,8 @@ async def test_journal_from_scanr_article(
         """
     service = SourceRecordService()
     await service.create_source_record(source_record=scanr_article_a_source_record_pydantic_model,
-                                       harvested_for=persisted_person_a_pydantic_model)
+                                       harvested_for=persisted_person_a_pydantic_model,
+                                       identifier_used=default_identifier_used)
     fetched_source_record = await service.get_source_record(
         scanr_article_a_source_record_pydantic_model.uid)
     assert fetched_source_record.source_identifier == "doi10.3847/1538-4357/ad0cc0"
@@ -203,7 +214,8 @@ async def test_journal_from_scanr_article(
 async def test_two_scanr_articles_from_same_journal_and_person(
         scanr_article_a_source_record_pydantic_model: SourceRecord,
         scanr_article_b_source_record_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ):
     """
     Given two source records from the same issue and journal and harvested for the same person
@@ -212,9 +224,11 @@ async def test_two_scanr_articles_from_same_journal_and_person(
     """
     service = SourceRecordService()
     await service.create_source_record(source_record=scanr_article_a_source_record_pydantic_model,
-                                       harvested_for=persisted_person_a_pydantic_model)
+                                       harvested_for=persisted_person_a_pydantic_model,
+                                       identifier_used=default_identifier_used)
     await service.create_source_record(source_record=scanr_article_b_source_record_pydantic_model,
-                                       harvested_for=persisted_person_a_pydantic_model)
+                                       harvested_for=persisted_person_a_pydantic_model,
+                                       identifier_used=default_identifier_used)
 
     fetched_source_record_a = await service.get_source_record(
         scanr_article_a_source_record_pydantic_model.uid)
@@ -250,7 +264,8 @@ async def test_two_scanr_articles_from_same_journal_and_person(
 async def test_create_two_source_records_with_same_concepts(
         persisted_person_a_pydantic_model: Person,
         idref_record_with_person_a_as_contributor_pydantic_model: SourceRecord,
-        scanr_record_with_person_a_as_contributor_pydantic_model: SourceRecord
+        scanr_record_with_person_a_as_contributor_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given a persisted person Pydantic model,
@@ -264,7 +279,8 @@ async def test_create_two_source_records_with_same_concepts(
     service = SourceRecordService()
     await service.create_source_record(
         source_record=idref_record_with_person_a_as_contributor_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_idref_source_record = await service.get_source_record(
         idref_record_with_person_a_as_contributor_pydantic_model.uid)
     assert (
@@ -273,7 +289,8 @@ async def test_create_two_source_records_with_same_concepts(
     )
     await service.create_source_record(
         source_record=scanr_record_with_person_a_as_contributor_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_scanr_source_record = await service.get_source_record(
         scanr_record_with_person_a_as_contributor_pydantic_model.uid)
     assert (
@@ -290,6 +307,7 @@ async def test_create_source_record_with_empty_uri_identifier(
         persisted_person_a_pydantic_model: Person,
         idref_record_with_person_a_as_contributor_empty_uri_json_data,
         idref_record_with_person_a_as_contributor_empty_uri_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given a persisted person Pydantic model,
@@ -304,7 +322,8 @@ async def test_create_source_record_with_empty_uri_identifier(
             == 4)
     await service.create_source_record(
         source_record=idref_record_with_person_a_as_contributor_empty_uri_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_idref_source_record = await service.get_source_record(
         idref_record_with_person_a_as_contributor_empty_uri_pydantic_model.uid)
     assert (
@@ -316,7 +335,8 @@ async def test_create_source_record_with_empty_uri_identifier(
 
 async def test_create_source_record_with_issue(
         persisted_person_a_pydantic_model: Person,
-        open_alex_article_source_record_with_issue_title_pydantic_model: SourceRecord
+        open_alex_article_source_record_with_issue_title_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given a persisted person pydantic model and a non persisted source record pydantic model
@@ -330,7 +350,8 @@ async def test_create_source_record_with_issue(
     assert len(open_alex_article_source_record_with_issue_title_pydantic_model.issue.titles) > 0
     await service.create_source_record(
         source_record=open_alex_article_source_record_with_issue_title_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_source_record = await service.get_source_record(
         open_alex_article_source_record_with_issue_title_pydantic_model.uid)
     assert fetched_source_record.issue
@@ -341,7 +362,8 @@ async def test_create_source_record_with_issue(
 
 async def test_create_source_record_with_issue_datetime_including_t(
         persisted_person_b_pydantic_model: Person,
-        scanr_record_with_person_b_as_contributor_pydantic_model: SourceRecord
+        scanr_record_with_person_b_as_contributor_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given a persisted person pydantic model and a non persisted source record pydantic model
@@ -355,9 +377,35 @@ async def test_create_source_record_with_issue_datetime_including_t(
     service = SourceRecordService()
     await service.create_source_record(
         source_record=scanr_record_with_person_b_as_contributor_pydantic_model,
-        harvested_for=persisted_person_b_pydantic_model)
+        harvested_for=persisted_person_b_pydantic_model,
+        identifier_used=default_identifier_used)
     assert await service.source_record_exists(
         scanr_record_with_person_b_as_contributor_pydantic_model.uid)
     fetched_source_record = await service.get_source_record(
         scanr_record_with_person_b_as_contributor_pydantic_model.uid)
     assert fetched_source_record.raw_issued == "2023-10-26"
+
+
+async def test_create_source_record_stores_identifier_used(
+        persisted_person_a_pydantic_model: Person,
+        scanr_thesis_source_record_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
+) -> None:
+    """
+    Given a source record created with a specific identifier_used,
+    When the source record uids are queried by identifier used,
+    Then the created source record uid is in the result.
+    """
+    factory = AbstractDAOFactory().get_dao_factory("neo4j")
+    source_record_dao: SourceRecordDAO = cast(SourceRecordDAO, factory.get_dao(SourceRecord))
+    service = SourceRecordService()
+    await service.create_source_record(
+        source_record=scanr_thesis_source_record_pydantic_model,
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
+    uids = await source_record_dao.get_source_record_uids_by_identifier_used(
+        person_uid=persisted_person_a_pydantic_model.uid,
+        identifier_used_type=PersonIdentifierType.IDREF,
+        identifier_used_value="122758765"
+    )
+    assert scanr_thesis_source_record_pydantic_model.uid in uids

--- a/tests/test_services/test_source_records_service_update.py
+++ b/tests/test_services/test_source_records_service_update.py
@@ -1,3 +1,4 @@
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.harvesters import Harvester
 from app.models.identifier_types import PublicationIdentifierType
 from app.models.people import Person
@@ -8,7 +9,8 @@ from app.services.source_records.source_record_service import SourceRecordServic
 async def test_update_scanr_article_source_record(
         scanr_article_a_source_record_persisted_model: SourceRecord,
         scanr_article_a_v2_source_record_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ):
     """
         Given a valid source record model recording an article harvested from ScanR
@@ -20,7 +22,8 @@ async def test_update_scanr_article_source_record(
     assert scanr_article_a_v2_source_record_pydantic_model.uid == common_uid
     await service.update_source_record(
         source_record=scanr_article_a_v2_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_source_record = await service.get_source_record(
         scanr_article_a_v2_source_record_pydantic_model.uid)
     assert fetched_source_record.source_identifier == "doi10.3847/1538-4357/ad0cc0"
@@ -60,7 +63,8 @@ async def test_update_scanr_article_source_record(
 async def test_update_hal_article_source_record_with_custom_metadata(
         hal_article_source_record_persisted_model: SourceRecord,
         hal_article_source_record_with_custom_metadata_v2_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ):
     """
         Given a valid source record model recording an article harvested from ScanR
@@ -72,7 +76,8 @@ async def test_update_hal_article_source_record_with_custom_metadata(
     assert hal_article_source_record_with_custom_metadata_v2_pydantic_model.uid == common_uid
     await service.update_source_record(
         source_record=hal_article_source_record_with_custom_metadata_v2_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_source_record = await service.get_source_record(
         hal_article_source_record_with_custom_metadata_v2_pydantic_model.uid)
     assert fetched_source_record.source_identifier == "hal-02732648"
@@ -108,7 +113,8 @@ async def test_double_update_scanr_article_source_record(
         scanr_article_a_source_record_persisted_model: SourceRecord,
         scanr_article_a_v2_source_record_pydantic_model: SourceRecord,
         scanr_article_a_v3_source_record_pydantic_model: SourceRecord,
-        persisted_person_a_pydantic_model: Person
+        persisted_person_a_pydantic_model: Person,
+        default_identifier_used: PersonIdentifier
 ):
     """
         Given a valid source record model recording an article harvested from ScanR
@@ -120,7 +126,8 @@ async def test_double_update_scanr_article_source_record(
     assert scanr_article_a_v2_source_record_pydantic_model.uid == common_uid
     await service.update_source_record(
         source_record=scanr_article_a_v2_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_source_record_v2 = await service.get_source_record(
         scanr_article_a_v2_source_record_pydantic_model.uid)
     assert any(
@@ -143,7 +150,8 @@ async def test_double_update_scanr_article_source_record(
     assert scanr_article_a_v3_source_record_pydantic_model.uid == common_uid
     await service.update_source_record(
         source_record=scanr_article_a_v3_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used
     )
     fetched_source_record_v3 = await service.get_source_record(
         scanr_article_a_v3_source_record_pydantic_model.uid
@@ -167,7 +175,8 @@ async def test_update_record_with_shared_concept(
         persisted_person_b_pydantic_model: Person,
         scanr_article_a_source_record_persisted_model: SourceRecord,
         scanr_article_c_source_record_persisted_model: SourceRecord,
-        scanr_article_c_v2_source_record_pydantic_model: SourceRecord
+        scanr_article_c_v2_source_record_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ):
     """
         Given two persisted source records with a shared concept
@@ -200,7 +209,8 @@ async def test_update_record_with_shared_concept(
 
     await service.update_source_record(
         source_record=scanr_article_c_v2_source_record_pydantic_model,
-        harvested_for=persisted_person_b_pydantic_model)
+        harvested_for=persisted_person_b_pydantic_model,
+        identifier_used=default_identifier_used)
     fetched_source_record_c_v2 = await service.get_source_record(
         scanr_article_c_v2_source_record_pydantic_model.uid)
 
@@ -226,6 +236,7 @@ async def test_update_source_record_issue(
         persisted_person_a_pydantic_model: Person,
         scanr_article_a_source_record_persisted_model: SourceRecord,
         scanr_article_a_source_record_with_updated_issue_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ):
     """
     Given a persisted source record with an issue
@@ -240,7 +251,8 @@ async def test_update_source_record_issue(
             scanr_article_a_source_record_persisted_model.issue)
     await service.update_source_record(
         source_record=scanr_article_a_source_record_with_updated_issue_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
 
     fetched_source_record_updated = await service.get_source_record(
         scanr_article_a_source_record_with_updated_issue_pydantic_model.uid)

--- a/tests/test_services/test_source_records_subjects_merge.py
+++ b/tests/test_services/test_source_records_subjects_merge.py
@@ -2,6 +2,7 @@ from typing import cast
 
 from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
 from app.graph.neo4j.document_dao import DocumentDAO
+from app.models.agent_identifiers import PersonIdentifier
 from app.models.document import Document
 from app.models.people import Person
 from app.models.source_records import SourceRecord
@@ -15,7 +16,8 @@ async def test_create_multiple_source_records_with_a_common_subject(
         persisted_person_b_pydantic_model: Person,
         scanr_article_a_v2_source_record_pydantic_model: SourceRecord,
         hal_article_a_source_record_pydantic_model: SourceRecord,
-        open_alex_article_a_source_record_pydantic_model: SourceRecord
+        open_alex_article_a_source_record_pydantic_model: SourceRecord,
+        default_identifier_used: PersonIdentifier
 ) -> None:
     """
     Given 3 source records with common hal identifier that have a common subject,
@@ -25,15 +27,18 @@ async def test_create_multiple_source_records_with_a_common_subject(
     source_record_service = SourceRecordService()
     await source_record_service.create_source_record(
         source_record=hal_article_a_source_record_pydantic_model,
-        harvested_for=persisted_person_a_pydantic_model)
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
 
     await source_record_service.create_source_record(
         source_record=scanr_article_a_v2_source_record_pydantic_model,
-        harvested_for=persisted_person_b_pydantic_model)
+        harvested_for=persisted_person_b_pydantic_model,
+        identifier_used=default_identifier_used)
 
     await source_record_service.create_source_record(
         source_record=open_alex_article_a_source_record_pydantic_model,
-        harvested_for=persisted_person_b_pydantic_model)
+        harvested_for=persisted_person_b_pydantic_model,
+        identifier_used=default_identifier_used)
 
     factory = AbstractDAOFactory().get_dao_factory("neo4j")
     document_dao: DocumentDAO = cast(DocumentDAO, factory.get_dao(Document))


### PR DESCRIPTION
- Store identifier_used_type/value on HARVESTED_FOR relationship
- Add mandatory identifier_used param to create/update source record service and route
- Parse harvesting field from AMQP reference messages
- Add get_source_record_uids_by_identifier_used DAO method and query
- Update all fixtures and tests accordingly