### PR TITLE
feat(ikg): allow memberships on all OrganizationUnit types

### DIFF
--- a/app/graph/neo4j/queries/create_membership.cypher
+++ b/app/graph/neo4j/queries/create_membership.cypher
@@ -1,3 +1,3 @@
 MATCH (p:Person {uid: $person_uid})
-MATCH (s:ResearchUnit {uid: $structure_uid})
+MATCH (s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Institution|Team {uid: $structure_uid})
 CREATE (p)-[:MEMBER_OF]->(s)

--- a/app/graph/neo4j/queries/create_membership.cypher
+++ b/app/graph/neo4j/queries/create_membership.cypher
@@ -1,3 +1,3 @@
 MATCH (p:Person {uid: $person_uid})
-MATCH (s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Institution|Team {uid: $structure_uid})
+MATCH (s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Team {uid: $structure_uid})
 CREATE (p)-[:MEMBER_OF]->(s)

--- a/app/graph/neo4j/queries/delete_person_memberships.cypher
+++ b/app/graph/neo4j/queries/delete_person_memberships.cypher
@@ -1,2 +1,2 @@
-MATCH (p:Person {uid: $person_uid})-[r:MEMBER_OF]->(s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Institution|Team)
+MATCH (p:Person {uid: $person_uid})-[r:MEMBER_OF]->(s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Team)
 DELETE r

--- a/app/graph/neo4j/queries/delete_person_memberships.cypher
+++ b/app/graph/neo4j/queries/delete_person_memberships.cypher
@@ -1,2 +1,2 @@
-MATCH (p:Person {uid: $person_uid})-[r:MEMBER_OF]->(s:ResearchUnit)
+MATCH (p:Person {uid: $person_uid})-[r:MEMBER_OF]->(s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Institution|Team)
 DELETE r

--- a/app/graph/neo4j/queries/find_person_by_identifier.cypher
+++ b/app/graph/neo4j/queries/find_person_by_identifier.cypher
@@ -2,7 +2,7 @@ MATCH (person:Person)-[:HAS_IDENTIFIER]->(filter:AgentIdentifier {type: $identif
 OPTIONAL MATCH (person)-[:HAS_NAME]->(pn:PersonName)
 OPTIONAL MATCH (pn)-[:HAS_FIRST_NAME]->(fn:Literal {type: 'person_first_name'})
 OPTIONAL MATCH (pn)-[:HAS_LAST_NAME]->(ln:Literal {type: 'person_last_name'})
-OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit)
+OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Institution|Team)
 OPTIONAL MATCH (person)-[emp:EMPLOYED_AT]->(inst:Institution)
 WITH person, pn, fn, ln, mb, rs, emp, inst
 MATCH (person)-[:HAS_IDENTIFIER]->(id:AgentIdentifier)

--- a/app/graph/neo4j/queries/find_person_by_identifier.cypher
+++ b/app/graph/neo4j/queries/find_person_by_identifier.cypher
@@ -2,7 +2,7 @@ MATCH (person:Person)-[:HAS_IDENTIFIER]->(filter:AgentIdentifier {type: $identif
 OPTIONAL MATCH (person)-[:HAS_NAME]->(pn:PersonName)
 OPTIONAL MATCH (pn)-[:HAS_FIRST_NAME]->(fn:Literal {type: 'person_first_name'})
 OPTIONAL MATCH (pn)-[:HAS_LAST_NAME]->(ln:Literal {type: 'person_last_name'})
-OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Institution|Team)
+OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Team)
 OPTIONAL MATCH (person)-[emp:EMPLOYED_AT]->(inst:Institution)
 WITH person, pn, fn, ln, mb, rs, emp, inst
 MATCH (person)-[:HAS_IDENTIFIER]->(id:AgentIdentifier)

--- a/app/graph/neo4j/queries/get_person_by_uid.cypher
+++ b/app/graph/neo4j/queries/get_person_by_uid.cypher
@@ -2,7 +2,7 @@ MATCH (person:Person {uid: $person_uid})
 OPTIONAL MATCH (person)-[:HAS_NAME]->(pn:PersonName)
 OPTIONAL MATCH (pn)-[:HAS_FIRST_NAME]->(fn:Literal {type: 'person_first_name'})
 OPTIONAL MATCH (pn)-[:HAS_LAST_NAME]->(ln:Literal {type: 'person_last_name'})
-OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Institution|Team)
+OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Team)
 OPTIONAL MATCH (person)-[emp:EMPLOYED_AT]->(inst:Institution)
 WITH person, pn, fn, ln, mb, rs, emp, inst
 OPTIONAL MATCH (person)-[:HAS_IDENTIFIER]->(id:AgentIdentifier)

--- a/app/graph/neo4j/queries/get_person_by_uid.cypher
+++ b/app/graph/neo4j/queries/get_person_by_uid.cypher
@@ -2,7 +2,7 @@ MATCH (person:Person {uid: $person_uid})
 OPTIONAL MATCH (person)-[:HAS_NAME]->(pn:PersonName)
 OPTIONAL MATCH (pn)-[:HAS_FIRST_NAME]->(fn:Literal {type: 'person_first_name'})
 OPTIONAL MATCH (pn)-[:HAS_LAST_NAME]->(ln:Literal {type: 'person_last_name'})
-OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit)
+OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Institution|Team)
 OPTIONAL MATCH (person)-[emp:EMPLOYED_AT]->(inst:Institution)
 WITH person, pn, fn, ln, mb, rs, emp, inst
 OPTIONAL MATCH (person)-[:HAS_IDENTIFIER]->(id:AgentIdentifier)

--- a/app/graph/neo4j/queries/research_unit_exists_by_uid.cypher
+++ b/app/graph/neo4j/queries/research_unit_exists_by_uid.cypher
@@ -1,2 +1,2 @@
-MATCH (s:ResearchUnit {uid: $uid})
+MATCH (s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Institution|Team {uid: $uid})
 RETURN s.uid AS uid LIMIT 1

--- a/tests/data/organizations/support_unit_a.json
+++ b/tests/data/organizations/support_unit_a.json
@@ -1,0 +1,19 @@
+{
+  "generic_type": "unit",
+  "main_mission": "scientific_services",
+  "secondary_missions": [],
+  "local_types": [],
+  "long_labels": [
+    {"value": "Plateforme de microscopie", "language": "fr"},
+    {"value": "Microscopy Platform", "language": "en"}
+  ],
+  "short_labels": [
+    {"value": "PM", "language": "fr"}
+  ],
+  "descriptions": [],
+  "identifiers": [
+    {"type": "local", "value": "SP001"}
+  ],
+  "relationships": [],
+  "contacts": []
+}

--- a/tests/data/people/person_a_with_support_unit_membership.json
+++ b/tests/data/people/person_a_with_support_unit_membership.json
@@ -1,0 +1,34 @@
+{
+  "names": [
+    {
+      "last_names": [
+        {
+          "value": "Doe",
+          "language": "fr"
+        }
+      ],
+      "first_names": [
+        {
+          "value": "John",
+          "language": "fr"
+        }
+      ]
+    }
+  ],
+  "identifiers": [
+    {
+      "type": "orcid",
+      "value": "0000-0001-2345-6789"
+    },
+    {
+      "type": "local",
+      "value": "jdoe@univ-domain.edu"
+    }
+  ],
+  "memberships": [
+    {
+      "entity_uid": "local-SP001"
+    }
+  ],
+  "employments": []
+}

--- a/tests/fixtures/organization_fixtures.py
+++ b/tests/fixtures/organization_fixtures.py
@@ -394,3 +394,24 @@ async def fixture_lra_research_unit_v2_json_data(_base_path) -> dict:
 async def fixture_lra_research_unit_v2_pydantic_model(
         lra_research_unit_v2_json_data) -> OrganizationBase:
     return _organization_unit_from_json_data(lra_research_unit_v2_json_data)
+
+
+@pytest_asyncio.fixture(name="support_unit_a_json_data")
+async def fixture_support_unit_a_json_data(_base_path) -> dict:
+    return _organization_unit_json_data_from_file(_base_path, "support_unit_a")
+
+
+@pytest_asyncio.fixture(name="support_unit_a_pydantic_model")
+async def fixture_support_unit_a_pydantic_model(support_unit_a_json_data) -> OrganizationBase:
+    return _organization_unit_from_json_data(support_unit_a_json_data)
+
+
+@pytest_asyncio.fixture(name="persisted_support_unit_a_pydantic_model")
+async def fixture_persisted_support_unit_a_pydantic_model(
+        support_unit_a_pydantic_model) -> OrganizationBase:
+    settings = get_app_settings()
+    factory = AbstractDAOFactory().get_dao_factory(settings.graph_db)
+    dao = factory.get_dao(OrganizationBase)
+    await dao.create(support_unit_a_pydantic_model)
+    return support_unit_a_pydantic_model
+

--- a/tests/fixtures/people_fixtures.py
+++ b/tests/fixtures/people_fixtures.py
@@ -559,3 +559,23 @@ async def fixture_person_f_json_data(_base_path) -> dict:
     :return: basic person json data
     """
     return _person_json_data_from_file(_base_path, "person_f")
+
+
+@pytest_asyncio.fixture(name="person_a_with_support_unit_membership_json_data")
+async def fixture_person_a_with_support_unit_membership_json_data(_base_path) -> dict:
+    """
+    Create a person json data with membership in a SupportUnit (scientific_services)
+    :return: person json data with SupportUnit membership
+    """
+    return _person_json_data_from_file(_base_path, "person_a_with_support_unit_membership")
+
+
+@pytest_asyncio.fixture(name="person_a_with_support_unit_membership_pydantic_model")
+async def fixture_person_a_with_support_unit_membership_pydantic_model(
+        person_a_with_support_unit_membership_json_data) -> Person:
+    """
+    Create a person pydantic model with membership in a SupportUnit
+    :return: person pydantic model with SupportUnit membership
+    """
+    return _person_from_json_data(person_a_with_support_unit_membership_json_data)
+

--- a/tests/test_graph/test_person_support_unit_membership.py
+++ b/tests/test_graph/test_person_support_unit_membership.py
@@ -1,0 +1,52 @@
+"""
+Integration tests verifying that a Person can be attached via MEMBER_OF
+to non-ResearchUnit OrganizationUnit types (e.g. SupportUnit).
+"""
+import pytest
+
+from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
+from app.models.identifier_types import PersonIdentifierType
+from app.models.organization_unit import OrganizationBase, SupportUnit
+from app.models.people import Person
+
+
+@pytest.mark.asyncio
+async def test_person_can_be_member_of_support_unit(
+        persisted_support_unit_a_pydantic_model: OrganizationBase,
+        person_a_with_support_unit_membership_pydantic_model: Person,
+):
+    """
+    Given a persisted SupportUnit (scientific_services mission)
+    And a Person whose membership points to that SupportUnit
+    When the person is created
+    Then the MEMBER_OF relationship to the SupportUnit should be persisted
+    and retrieved correctly.
+    """
+    factory = AbstractDAOFactory().get_dao_factory("neo4j")
+    person_dao = factory.get_dao(Person)
+
+    # Persist the person
+    await person_dao.create(person_a_with_support_unit_membership_pydantic_model)
+
+    # Retrieve by local identifier
+    local_identifier = person_a_with_support_unit_membership_pydantic_model.get_identifier(
+        PersonIdentifierType.LOCAL
+    )
+    person_from_db = await person_dao.find_by_identifier(
+        local_identifier.type, local_identifier.value
+    )
+
+    assert person_from_db is not None, "Person should exist in the database"
+    assert len(person_from_db.memberships) == 1, (
+        "Person should have exactly one membership"
+    )
+
+    membership = person_from_db.memberships[0]
+    assert membership.entity_uid == "local-SP001", (
+        "Membership entity_uid should point to the SupportUnit"
+    )
+
+    # Also verify the SupportUnit itself has the correct type
+    assert isinstance(persisted_support_unit_a_pydantic_model, SupportUnit), (
+        "The persisted structure should be a SupportUnit"
+    )


### PR DESCRIPTION
- Replaced ResearchUnit with an explicit OR-list in create_membership.cypher and delete_person_memberships.cypher
- Updated research_unit_exists_by_uid.cypher to validate existence of any OrganizationUnit type
- Updated get_person_by_uid.cypher and find_person_by_identifier.cypher to return memberships to any OrganizationUnit type

This ensures full support for attaching researchers to SupportUnit, InstitutionSubdivision, AdministrativeUnit, etc.