### PR TITLE
feat(#391): handle full-state contribution update message from sovisu…

### DIFF
--- a/app/graph/neo4j/document_dao.py
+++ b/app/graph/neo4j/document_dao.py
@@ -268,7 +268,8 @@ class DocumentDAO(Neo4jDAO):
             self,
             document_uid: str,
             person_uid: str,
-            roles: list[str]
+            roles: list[str],
+            rank: int | None = None
     ) -> str | None:
         """
         Create a Contribution node and establish relationships to the Document and Person.
@@ -276,6 +277,7 @@ class DocumentDAO(Neo4jDAO):
         :param document_uid: UID of the Document.
         :param person_uid: UID of the Person.
         :param roles: List of roles to attach to the contribution.
+        :param rank: Optional rank (card position) of the contribution.
         :return: UID of the created Contribution.
         """
         async with Neo4jConnexion().get_driver() as driver:
@@ -284,7 +286,8 @@ class DocumentDAO(Neo4jDAO):
                     self._create_contribution_transaction,
                     document_uid,
                     person_uid,
-                    roles
+                    roles,
+                    rank
                 )
 
     @staticmethod
@@ -292,7 +295,8 @@ class DocumentDAO(Neo4jDAO):
             tx: AsyncManagedTransaction,
             document_uid: str,
             person_uid: str,
-            roles: list[str]
+            roles: list[str],
+            rank: int | None = None
     ) -> str | None:
         """
         Transaction to create Contribution and link it to Document and Person.
@@ -301,6 +305,7 @@ class DocumentDAO(Neo4jDAO):
         :param document_uid: UID of the Document.
         :param person_uid: UID of the Person.
         :param roles: List of roles to attach to the contribution.
+        :param rank: Optional rank (card position) of the contribution.
         :return: id of the created Contribution.
         """
         query = load_query("create_contribution_to_document")
@@ -308,7 +313,8 @@ class DocumentDAO(Neo4jDAO):
             query,
             document_uid=document_uid,
             person_uid=person_uid,
-            roles=roles
+            roles=roles,
+            rank=rank
         )
         single = await result.single()
         if single is None:

--- a/app/graph/neo4j/person_dao.py
+++ b/app/graph/neo4j/person_dao.py
@@ -437,6 +437,62 @@ class PersonDAO(Neo4jDAO):
         record = await result.single()
         return record["uid"] if record else None
 
+    async def find_candidates_by_identifiers(self, identifiers: list[dict]) -> list[dict]:
+        """
+        Find every Person matching any of the provided identifiers, either through their
+        AgentIdentifiers (internal people) or through their source people's
+        SourcePersonIdentifiers (external people).
+
+        Unlike :meth:`find_by_identifiers` (AgentIdentifier-only, first match), this returns
+        all candidates together with the identifier that matched, so the caller can
+        disambiguate between several persons and discard inconsistent identifiers.
+
+        :param identifiers: List of dictionaries with 'type' and 'value'.
+        :return: list of dicts with keys id_type, id_value, person_uid, external, display_name.
+        """
+        if not identifiers:
+            return []
+        async with Neo4jConnexion().get_driver() as driver:
+            async with driver.session() as session:
+                return await session.read_transaction(
+                    self._find_candidates_by_identifiers_transaction, identifiers)
+
+    @staticmethod
+    async def _find_candidates_by_identifiers_transaction(
+            tx: AsyncManagedTransaction, identifiers: list[dict]
+    ) -> list[dict]:
+        """
+        Transaction backing :meth:`find_candidates_by_identifiers`.
+        """
+        query = load_query("find_person_candidates_by_identifiers")
+        result = await tx.run(query, identifiers=identifiers)
+        return await result.data()
+
+    async def add_person_identifiers(self, person_uid: str, identifiers: list[dict]) -> None:
+        """
+        Add AgentIdentifiers to an existing person without touching its names or other
+        identifiers (MERGE-based, idempotent).
+
+        :param person_uid: UID of the person.
+        :param identifiers: List of dictionaries with 'type' and 'value'.
+        """
+        if not identifiers:
+            return
+        async with Neo4jConnexion().get_driver() as driver:
+            async with driver.session() as session:
+                await session.write_transaction(
+                    self._add_person_identifiers_transaction, person_uid, identifiers)
+
+    @staticmethod
+    async def _add_person_identifiers_transaction(
+            tx: AsyncManagedTransaction, person_uid: str, identifiers: list[dict]
+    ) -> None:
+        """
+        Transaction backing :meth:`add_person_identifiers`.
+        """
+        query = load_query("create_person_identifiers")
+        await tx.run(query, person_uid=person_uid, identifiers=identifiers)
+
     @staticmethod
     def _hydrate(record) -> Person:
         person_data = record["person"]
@@ -469,6 +525,9 @@ class PersonDAO(Neo4jDAO):
             )
         person = Person(
             uid=person_data["uid"],
+            display_name=person_data.get("display_name"),
+            display_name_variants=person_data.get("display_name_variants") or [],
+            external=person_data.get("external", False),
             identifiers=identifiers,
             names=names,
             memberships=memberships,

--- a/app/graph/neo4j/queries/create_contribution_to_document.cypher
+++ b/app/graph/neo4j/queries/create_contribution_to_document.cypher
@@ -1,6 +1,6 @@
 MERGE (doc:Document {uid: $document_uid})
 MERGE (person:Person {uid: $person_uid})
 MERGE (doc)-[:HAS_CONTRIBUTION]->(contribution:Contribution)<-[:HAS_CONTRIBUTION]-(person)
-ON CREATE SET contribution.roles = $roles
-ON MATCH SET contribution.roles = $roles
+ON CREATE SET contribution.roles = $roles, contribution.rank = $rank
+ON MATCH SET contribution.roles = $roles, contribution.rank = $rank
 RETURN elementId(contribution) AS contribution_id

--- a/app/graph/neo4j/queries/find_person_candidates_by_identifiers.cypher
+++ b/app/graph/neo4j/queries/find_person_candidates_by_identifiers.cypher
@@ -1,0 +1,16 @@
+UNWIND $identifiers AS identifier
+CALL {
+  WITH identifier
+  MATCH (p:Person)-[:HAS_IDENTIFIER]->(:AgentIdentifier {type: identifier.type, value: identifier.value})
+  RETURN p
+  UNION
+  WITH identifier
+  MATCH (p:Person)-[:RECORDED_BY]->(:SourcePerson)-[:HAS_IDENTIFIER]->(:SourcePersonIdentifier {type: identifier.type, value: identifier.value})
+  RETURN p
+}
+RETURN DISTINCT
+  identifier.type AS id_type,
+  identifier.value AS id_value,
+  p.uid AS person_uid,
+  p.external AS external,
+  p.display_name AS display_name

--- a/app/services/authority_organizations/authority_organization_location_service.py
+++ b/app/services/authority_organizations/authority_organization_location_service.py
@@ -29,8 +29,12 @@ class AuthorityOrganizationLocationService:
         state = await auth_org_dao.get_authority_organization_state_by_uid(state_uid)
 
         source_org_dao = self._get_source_org_dao()
-        source_orgs = [await source_org_dao.get_by_uid(uid) for uid
-                       in state.source_organization_uids]
+        # some source organization uids may not have a backing node in the graph
+        # (e.g. affiliations resolved in-memory from a user contribution update)
+        source_orgs = [source_org for source_org in
+                       [await source_org_dao.get_by_uid(uid)
+                        for uid in state.source_organization_uids]
+                       if source_org is not None]
 
         address_list = []
         place_list = []

--- a/app/services/changes/change_processor_factory.py
+++ b/app/services/changes/change_processor_factory.py
@@ -3,6 +3,8 @@ from app.models.change import Change, TargetType
 from app.services.changes.processors.abstract_change_processor import AbstractChangeProcessor
 from app.services.changes.processors.document_abstract_change_processor import \
     DocumentAbstractChangeProcessor
+from app.services.changes.processors.document_contributions_change_processor import \
+    DocumentContributionsChangeProcessor
 from app.services.changes.processors.document_merge_change_processor import \
     DocumentMergeChangeProcessor
 from app.services.changes.processors.document_subjects_change_processor import (
@@ -28,6 +30,9 @@ class ChangeProcessorFactory:
         if change.target_type == TargetType.DOCUMENT:
             if change.action_type == "MERGE":
                 return DocumentMergeChangeProcessor(change)
+
+            if change.path == "contributions":
+                return DocumentContributionsChangeProcessor(change)
 
             if change.path == "subjects":
                 return DocumentSubjectsChangeProcessor(change)

--- a/app/services/changes/change_service.py
+++ b/app/services/changes/change_service.py
@@ -20,11 +20,13 @@ class ChangeService:
     Service for managing changes in the graph.
     """
 
-    async def create_and_apply_change(self, change: Change) -> None:
+    async def create_and_apply_change(
+            self, change: Change, mode: MessageMode = MessageMode.INTERACTIVE) -> None:
         """
         Create a Change node if it does not exist, or update the status if it does.
         This method is intended to "on the fly" apply changes to the graph.
         :param change:
+        :param mode: message mode for the outbound document-updated event
         :return:
         """
         existing = await self._change_dao().get_by_uid(change.uid)
@@ -37,11 +39,11 @@ class ChangeService:
                 logger.info(f"Change {change.uid} had failed. Retrying.")
                 return
             logger.info(f"Change {change.uid} found bu not applied. Applying.")
-            await self.apply_change(existing)
+            await self.apply_change(existing, mode=mode)
         else:
             logger.info(f"Change {change.uid} not found. Creating and applying.")
             await self.create_change(change)
-            await self.apply_change(change)
+            await self.apply_change(change, mode=mode)
 
     async def create_change(self, change: Change) -> Change:
         """
@@ -58,10 +60,12 @@ class ChangeService:
             change.status = ChangeStatus.CREATED
             return await self._change_dao().create_document_change(document, change)
 
-    async def apply_change(self, change: Change) -> None:
+    async def apply_change(
+            self, change: Change, mode: MessageMode = MessageMode.INTERACTIVE) -> None:
         """
         Apply a change to the graph.
         :param change:
+        :param mode: message mode for the outbound document-updated event
         :return:
         """
         try:
@@ -72,7 +76,7 @@ class ChangeService:
             # for MERGE changes, the document_updated signal is sent by the processor
             if change.target_type == TargetType.DOCUMENT and change.action_type not in ("MERGE"):
                 await document_updated.send_async(self, document_uid=change.target_uid,
-                                                  mode=MessageMode.INTERACTIVE)
+                                                  mode=mode)
         except (DatabaseError, ValueError) as e:
             change.status = ChangeStatus.FAILED
             change.error_message = str(e)
@@ -80,21 +84,34 @@ class ChangeService:
             logger.error(f"Failed to apply change {change.uid}: {e}")
             raise e
 
-    async def apply_changes_to_node(self, target_uid: str) -> None:
+    async def apply_changes_to_node(
+            self, target_uid: str, mode: MessageMode = MessageMode.BATCH) -> None:
         """
         Apply all changes related to a specific target UID.
+
+        Contribution changes carry full state, so only the latest ``contributions`` change is
+        applied; older ones are superseded (kept in the graph for history, not replayed).
         :param target_uid:
+        :param mode: message mode for the outbound document-updated events
         :return:
         """
         changes = await self._change_dao().get_changes_by_target_uid(
             target_uid=target_uid
         )
+        # changes are returned ordered by timestamp ASC, so the last one wins
+        latest_contributions_uid = None
+        for change in changes:
+            if change.path == "contributions":
+                latest_contributions_uid = change.uid
         for change in changes:
             if change.action_type == "MERGE":
                 # Skip merge changes to avoid infinite loops
                 continue
+            # supersession: only the latest contributions change is replayed
+            if change.path == "contributions" and change.uid != latest_contributions_uid:
+                continue
             try:
-                await self.apply_change(change)
+                await self.apply_change(change, mode=mode)
             except (DatabaseError, ValueError) as e:
                 logger.error(f"Failed to apply change {change.uid} to {target_uid}: {e}")
 

--- a/app/services/changes/processors/document_contributions_change_processor.py
+++ b/app/services/changes/processors/document_contributions_change_processor.py
@@ -1,0 +1,28 @@
+from app.services.changes.processors.abstract_change_processor import AbstractChangeProcessor
+from app.services.contributions.contribution_update_service import ContributionUpdateService
+
+
+class DocumentContributionsChangeProcessor(AbstractChangeProcessor):
+    """
+    Processor for a full-state contribution update of a Document.
+
+    The change carries the complete desired contributor list in
+    ``parameters["contributions"]``; the document's contributions are reconciled to exactly
+    that list (replace semantics).
+    """
+
+    async def apply(self) -> None:
+        document_uid = self.change.target_uid
+        if not isinstance(document_uid, str):
+            raise ValueError(f"Invalid 'targetUid' in change: {self.change.target_uid}")
+
+        contributions = self.change.parameters.get("contributions")
+        if not isinstance(contributions, list):
+            raise ValueError(
+                f"Invalid 'contributions' in parameters of change {self.change.uid}: "
+                f"expected a list, got {type(contributions).__name__}")
+
+        await ContributionUpdateService().reconcile(
+            document_uid=document_uid,
+            contributions=contributions,
+        )

--- a/app/services/contributions/contribution_update_service.py
+++ b/app/services/contributions/contribution_update_service.py
@@ -1,0 +1,279 @@
+from collections import defaultdict
+from typing import cast, Optional
+
+from loguru import logger
+
+from app.config import get_app_settings
+from app.errors.conflict_error import ConflictError
+from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
+from app.graph.generic.dao_factory import DAOFactory
+from app.graph.neo4j.document_dao import DocumentDAO
+from app.graph.neo4j.person_dao import PersonDAO
+from app.models.document import Document
+from app.models.harvesting_sources import HarvestingSource
+from app.models.people import Person
+from app.models.source_organization_identifiers import SourceOrganizationIdentifier
+from app.models.source_organizations import SourceOrganization
+from app.services.authority_organizations.authority_organization_service import \
+    AuthorityOrganizationService
+from app.services.source_contributors.source_contributor_mapping_service import \
+    SourceContributorMappingService
+from app.utils.name_matching import fuzz_distance
+
+
+class ContributionUpdateService:
+    """
+    Reconcile a document's contributions against the full, authoritative contributor list
+    carried by a sovisuplus contribution-update message (replace semantics).
+
+    Contributors present in the list are created/updated, contributors absent from it are
+    removed. Person identifiers are frozen for internal people and updatable for external
+    people; affiliations are resolved to authority organizations using the existing
+    in-memory authority resolution algorithm (no source-layer node is persisted).
+    """
+
+    # HAL structure types (message ``type``) → in-memory SourceOrganisationType
+    _ORG_TYPE_MAP = {
+        "institution": SourceOrganization.SourceOrganisationType.INSTITUTION,
+        "regroupinstitution": SourceOrganization.SourceOrganisationType.INSTITUTION_GROUP,
+        "laboratory": SourceOrganization.SourceOrganisationType.LABORATORY,
+        "regrouplaboratory": SourceOrganization.SourceOrganisationType.LABORATORY_GROUP,
+        "researchteam": SourceOrganization.SourceOrganisationType.RESEARCH_TEAM,
+        "regroupresearchteam": SourceOrganization.SourceOrganisationType.RESEARCH_TEAM_GROUP,
+    }
+
+    # Affiliation identifier keys carried inline in the message (besides the HAL structId)
+    _AFFILIATION_IDENTIFIER_KEYS = ("idref", "ror", "isni", "nns", "wikidata")
+
+    def __init__(self) -> None:
+        self.authority_organization_service = AuthorityOrganizationService()
+
+    async def reconcile(self, document_uid: str, contributions: list[dict]) -> None:
+        """
+        Reconcile the document's contributions to exactly the submitted list.
+
+        :param document_uid: target document uid
+        :param contributions: full ordered contribution list from the message
+        """
+        document_dao = self._document_dao()
+        contribution_ids: list[str] = []
+        for contribution in contributions:
+            person = contribution.get("person") or {}
+            person_uid = await self._resolve_person(person)
+            if person_uid is None:
+                logger.warning("Skipping contribution with unresolvable person: %s", person)
+                continue
+            roles = contribution.get("roles") or []
+            rank = contribution.get("rank")
+            contribution_id = await document_dao.create_contribution(
+                document_uid=document_uid,
+                person_uid=person_uid,
+                roles=roles,
+                rank=rank,
+            )
+            if contribution_id is None:
+                continue
+            targets = await self._resolve_affiliations(contribution.get("affiliations") or [])
+            await document_dao.update_contribution_affiliation_statements(
+                contribution_id=contribution_id,
+                targets=targets,
+            )
+            contribution_ids.append(contribution_id)
+        # Remove contributors absent from the submitted list
+        await document_dao.delete_contributions_not_in(
+            document_uid=document_uid,
+            contribution_ids=contribution_ids,
+        )
+
+    # ------------------------------------------------------------------ persons
+
+    async def _resolve_person(self, person: dict) -> Optional[str]:
+        """
+        Resolve the contribution's person to a graph Person uid, creating a new external
+        person when necessary, and applying the internal/external identifier policy.
+        """
+        uid = person.get("uid")
+        incoming_identifiers = self._incoming_identifiers(person)
+        display_name = person.get("displayName") or person.get("display_name")
+
+        if uid:
+            existing = await self._person_dao().get(uid)
+            if existing is not None:
+                await self._apply_identifier_policy(
+                    existing.uid, bool(existing.external), incoming_identifiers, set())
+                return existing.uid
+            # uid provided but not found: fall back to matching/creation
+            logger.info("Person uid %s not found, falling back to identifier matching", uid)
+
+        return await self._match_or_create_person(incoming_identifiers, display_name)
+
+    async def _match_or_create_person(
+            self, incoming_identifiers: list[dict], display_name: Optional[str]
+    ) -> Optional[str]:
+        candidates = await self._person_dao().find_candidates_by_identifiers(incoming_identifiers)
+
+        persons: dict[str, dict] = {}
+        id_to_persons: dict[tuple, set] = defaultdict(set)
+        for row in candidates:
+            persons[row["person_uid"]] = {
+                "external": row.get("external"),
+                "display_name": row.get("display_name"),
+            }
+            id_to_persons[(row["id_type"], row["id_value"])].add(row["person_uid"])
+
+        distinct = list(persons.keys())
+        if not distinct:
+            return await self._create_external_person(incoming_identifiers, display_name)
+
+        if len(distinct) == 1:
+            selected = distinct[0]
+        else:
+            selected = self._select_by_name_similarity(distinct, persons, display_name)
+
+        await self._apply_identifier_policy(
+            selected, bool(persons[selected]["external"]), incoming_identifiers,
+            self._inconsistent_identifier_keys(id_to_persons, selected))
+        return selected
+
+    @staticmethod
+    def _inconsistent_identifier_keys(id_to_persons: dict[tuple, set], selected: str) -> set:
+        """
+        Identifier (type, value) keys that point to a person other than the selected one and
+        must therefore not be written onto the selected person.
+        """
+        return {key for key, owners in id_to_persons.items() if owners - {selected}}
+
+    async def _apply_identifier_policy(
+            self,
+            person_uid: str,
+            external: bool,
+            incoming_identifiers: list[dict],
+            inconsistent_keys: set,
+    ) -> None:
+        """
+        Internal people: identifiers are frozen (incoming identifiers ignored).
+        External people: add the consistent incoming identifiers (MERGE, names untouched).
+        """
+        if not external:
+            return
+        consistent = [
+            identifier for identifier in incoming_identifiers
+            if (identifier["type"], identifier["value"]) not in inconsistent_keys
+        ]
+        await self._person_dao().add_person_identifiers(person_uid, consistent)
+
+    @staticmethod
+    def _select_by_name_similarity(
+            uids: list[str], persons: dict[str, dict], submitted_name: Optional[str]
+    ) -> str:
+        if not submitted_name:
+            return uids[0]
+        best_uid = uids[0]
+        best_score = -1.0
+        for uid in uids:
+            score = fuzz_distance(submitted_name, persons[uid]["display_name"] or "")
+            if score > best_score:
+                best_score = score
+                best_uid = uid
+        return best_uid
+
+    async def _create_external_person(
+            self, incoming_identifiers: list[dict], display_name: Optional[str]
+    ) -> Optional[str]:
+        if not display_name:
+            logger.warning("Cannot create external person without a display name")
+            return None
+        person = Person(
+            uid=None,
+            display_name=display_name,
+            external=True,
+            identifiers=incoming_identifiers,
+        )
+        try:
+            person_uid, _, _ = await self._person_dao().create(person)
+            return person_uid
+        except (ConflictError, ValueError) as error:
+            logger.error("Could not create external person %s: %s", display_name, error)
+            return None
+
+    @staticmethod
+    def _incoming_identifiers(person: dict) -> list[dict]:
+        identifiers = person.get("identifiers") or []
+        return [
+            {"type": identifier["type"], "value": identifier["value"]}
+            for identifier in identifiers
+            if identifier.get("type") and identifier.get("value")
+        ]
+
+    # ------------------------------------------------------------- affiliations
+
+    async def _resolve_affiliations(self, affiliations: list[dict]) -> list[str]:
+        """
+        Resolve message affiliations to elected authority-organization target uids, reusing
+        the existing in-memory authority resolution (no SourceOrganization node persisted).
+        """
+        source_organisations = [
+            org for org in (self._build_source_organization(aff) for aff in affiliations)
+            if org is not None
+        ]
+        if not source_organisations:
+            return []
+
+        root_objects = []
+        seen: set = set()
+        for organisation in source_organisations:
+            if organisation.uid in seen:
+                continue
+            seen.add(organisation.uid)
+            try:
+                root = await self.authority_organization_service\
+                    .get_or_create_authority_organization([organisation])
+                root_objects.append(root)
+            except ConflictError as error:
+                logger.error(
+                    "Conflict error while resolving affiliation %s: %s", organisation.uid, error)
+
+        # pylint: disable=protected-access
+        return SourceContributorMappingService\
+            ._elect_authority_organizations_for_affiliation_statements(
+                root_objects, source_organisations)
+
+    def _build_source_organization(self, affiliation: dict) -> Optional[SourceOrganization]:
+        source_identifier = affiliation.get("hal")
+        if not source_identifier:
+            # affiliations are normally HAL-sourced; fall back to any other identifier
+            for key in self._AFFILIATION_IDENTIFIER_KEYS:
+                if affiliation.get(key):
+                    source_identifier = affiliation.get(key)
+                    break
+        if not source_identifier:
+            logger.warning("Affiliation without usable identifier skipped: %s", affiliation)
+            return None
+
+        identifiers = [
+            SourceOrganizationIdentifier(type=key, value=affiliation[key])
+            for key in self._AFFILIATION_IDENTIFIER_KEYS
+            if affiliation.get(key)
+        ]
+        return SourceOrganization(
+            source=HarvestingSource.HAL,
+            source_identifier=str(source_identifier),
+            name=affiliation.get("name") or affiliation.get("label") or "",
+            type=self._ORG_TYPE_MAP.get(
+                affiliation.get("type"),
+                SourceOrganization.SourceOrganisationType.ORGANIZATION),
+            identifiers=identifiers,
+        )
+
+    # --------------------------------------------------------------------- daos
+
+    def _document_dao(self) -> DocumentDAO:
+        return cast(DocumentDAO, self._get_dao_factory().get_dao(Document))
+
+    def _person_dao(self) -> PersonDAO:
+        return cast(PersonDAO, self._get_dao_factory().get_dao(Person))
+
+    @staticmethod
+    def _get_dao_factory() -> DAOFactory:
+        settings = get_app_settings()
+        return AbstractDAOFactory().get_dao_factory(settings.graph_db)

--- a/app/services/documents/document_service.py
+++ b/app/services/documents/document_service.py
@@ -34,7 +34,8 @@ class DocumentService:
         :param mode: message mode for outbound events
         :return:
         """
-        to_be_deleted = not await self._compute_document_from_source_records(document_uid)
+        to_be_deleted = not await self._compute_document_from_source_records(
+            document_uid, mode=mode)
         if to_be_deleted:
             await self.signal_document_deleted(document_uid, mode=mode)
         else:
@@ -51,7 +52,7 @@ class DocumentService:
         :return:
         """
         # fetch the source records to be merged
-        await self._compute_document_from_source_records(document_uid)
+        await self._compute_document_from_source_records(document_uid, mode=mode)
         await self.signal_document_created(document_uid, mode=mode)
         await literal_updated.send_async(self)
 
@@ -94,10 +95,12 @@ class DocumentService:
         svc = EquivalenceService()
         await svc.update_source_record(self, representative_uid, mode=mode)
 
-    async def _compute_document_from_source_records(self, document_uid) -> bool:
+    async def _compute_document_from_source_records(
+            self, document_uid, mode: MessageMode = MessageMode.BATCH) -> bool:
         """
         Compute the metadata of a document from its source records
         :param document_uid:
+        :param mode: message mode for outbound events emitted while replaying changes
         :return: False if the document should be deleted (i.e. has no source records)
         """
         sources_records = await self._get_source_records_of_document(document_uid)
@@ -131,7 +134,7 @@ class DocumentService:
         # import dynamically to avoid circular imports
         # pylint: disable=import-outside-toplevel,cyclic-import
         from app.services.changes.change_service import ChangeService
-        await ChangeService().apply_changes_to_node(document_uid)
+        await ChangeService().apply_changes_to_node(document_uid, mode=mode)
         return True
 
     async def signal_document_updated(self, document_uid, mode: MessageMode = MessageMode.BATCH):

--- a/app/services/source_contributors/source_contributor_mapping_service.py
+++ b/app/services/source_contributors/source_contributor_mapping_service.py
@@ -1,9 +1,5 @@
-import re
-import unicodedata
 from typing import cast, AsyncGenerator, List
 from venv import logger
-
-from rapidfuzz import fuzz
 
 from app.config import get_app_settings
 from app.errors.conflict_error import ConflictError
@@ -25,6 +21,7 @@ from app.models.source_records import SourceRecord
 from app.services.authority_organizations.authority_organization_service import \
     AuthorityOrganizationService
 from app.services.source_contributors.source_organization_service import SourceOrganizationService
+from app.utils.name_matching import normalize_name, fuzz_distance
 
 
 class SourceContributorMappingService:
@@ -263,7 +260,8 @@ class SourceContributorMappingService:
             contribution_ids=list(current_contribution_ids)
         )
 
-    def _elect_authority_organizations_for_affiliation_statements(self, root_objects,
+    @staticmethod
+    def _elect_authority_organizations_for_affiliation_statements(root_objects,
                                                                   source_organisations):
         # elect one target per root: either a state (unique match) or the root (0 or multiple
         # matches)
@@ -497,20 +495,7 @@ class SourceContributorMappingService:
         return distance
 
     def _normalize_string(self, input_string):
-        # Convert to lowercase
-        normalized = input_string.lower()
-
-        # Replace accented characters with their ASCII equivalents
-        normalized = unicodedata.normalize('NFD', normalized)
-        normalized = ''.join(char for char in normalized if unicodedata.category(char) != 'Mn')
-
-        # Replace all non-letter characters with spaces
-        normalized = re.sub(r'[^a-z]', ' ', normalized)
-
-        # Remove extra spaces
-        normalized = re.sub(r'\s+', ' ', normalized).strip()
-
-        return normalized
+        return normalize_name(input_string)
 
     def _coauthor_names_maximal_distance(self):
         settings = get_app_settings()
@@ -538,7 +523,7 @@ class SourceContributorMappingService:
         :param name2: Second name
         :return: normalized Levenshtein distance
         """
-        return fuzz.token_sort_ratio(name1, name2, processor=self._normalize_string)
+        return fuzz_distance(name1, name2)
 
     def _is_similar(self, internal_person: Person, external_people: list[SourcePerson]) -> bool:
         """

--- a/app/utils/name_matching.py
+++ b/app/utils/name_matching.py
@@ -1,0 +1,47 @@
+"""
+Shared name-matching helpers (normalization + fuzzy distance).
+
+Extracted so that both the source-record contributor mapping
+(:class:`SourceContributorMappingService`) and the user-driven contribution
+update path (:class:`ContributionUpdateService`) rely on the exact same
+name-similarity logic instead of duplicating it.
+"""
+import re
+import unicodedata
+
+from rapidfuzz import fuzz
+
+
+def normalize_name(input_string: str) -> str:
+    """
+    Normalize a name for comparison: lowercase, strip diacritics, keep letters
+    only and collapse whitespace.
+
+    :param input_string: raw name
+    :return: normalized name (may be empty)
+    """
+    normalized = (input_string or "").lower()
+
+    # Replace accented characters with their ASCII equivalents
+    normalized = unicodedata.normalize('NFD', normalized)
+    normalized = ''.join(char for char in normalized if unicodedata.category(char) != 'Mn')
+
+    # Replace all non-letter characters with spaces
+    normalized = re.sub(r'[^a-z]', ' ', normalized)
+
+    # Remove extra spaces
+    normalized = re.sub(r'\s+', ' ', normalized).strip()
+
+    return normalized
+
+
+def fuzz_distance(name1: str, name2: str) -> float:
+    """
+    Token-sort similarity ratio (0-100) between two names, computed on their
+    normalized forms.
+
+    :param name1: first name
+    :param name2: second name
+    :return: similarity ratio in [0, 100]
+    """
+    return fuzz.token_sort_ratio(name1, name2, processor=normalize_name)

--- a/specs/handle-contribution-update-message-from-sovisuplus#391/prompt.md
+++ b/specs/handle-contribution-update-message-from-sovisuplus#391/prompt.md
@@ -1,0 +1,392 @@
+# Handle contribution update message coming from sovisuplus
+
+Issue: https://github.com/CRISalid-esr/crisalid-ikg/issues/391
+
+## Context
+
+When a user edits the **Authors** tab of a document in sovisuplus and clicks *save*, sovisuplus
+emits **one authoritative message describing the new, complete state of the document's
+contributions**.
+
+This replaces the originally-proposed series of atomic per-change messages (one `ADD` / `UPDATE` /
+`REMOVE` per contributor, sequenced with `id` / `nextId`). The sovisuplus side has already been
+changed accordingly — see
+`/home/joachim/WebstormProjects/sovisuplus/specs/send-global-contributor-update-message/prompt.md`.
+
+CRISalid IKG must receive this single message and **replace** the document's contribution set with
+the state it carries:
+
+- contributors present in the message are created / updated;
+- contributors absent from it are removed;
+- an empty contribution list removes all contributors.
+
+The message is treated as **declarative full state**, not a delta. This matters because the change is
+applied in two contexts:
+
+1. **Interactive** — the user saves in the Authors tab (this message), processed from the
+   interactive user-actions queue.
+2. **Batch replay** — when the document is recomputed/merged from source records (harvesting), the
+   stored `Change` is replayed via `ChangeService.apply_changes_to_node()`
+   (`app/services/documents/document_service.py`). A declarative full-state change replays
+   idempotently against a regenerated contribution graph; uid-keyed deltas would not.
+
+The only difference between the two contexts is the **queue / `MessageMode`** of the outbound
+"document updated" message (interactive vs batch).
+
+## Message contract
+
+- `actionType`: `"UPDATE"` (reused; no new action type)
+- `targetType`: `"DOCUMENT"`
+- `path`: `"contributions"`
+- Routing key: `task.documents.document.update` (→ inbound user-actions queue)
+- `parameters.contributions`: the **complete, ordered** list of contributions the document should
+  have after the save.
+
+### `parameters` shape
+
+```json
+{
+  "contributions": [
+    {
+      "rank": "number | null",          // card position when ranking mode is on, else null
+      "roles": ["string"],              // LoC relator URIs, e.g. http://id.loc.gov/vocabulary/relators/aut
+      "person": {
+        "uid": "string | null",         // null = brand-new person; graph mints/matches by identifiers
+        "displayName": "string",
+        "firstName": "string | null",
+        "lastName": "string | null",
+        "identifiers": [
+          { "type": "string", "value": "string" }
+        ]
+      },
+      "affiliations": [
+        {
+          "acronym":  "string | null",
+          "name":     "string | null",
+          "label":    "string | null",
+          "type":     "string | null",  // e.g. "institution", "regrouplaboratory"
+          "hal":      "string | null",  // identifier values per source
+          "idref":    "string | null",
+          "isni":     "string | null",
+          "nns":      "string | null",
+          "ror":      "string | null",
+          "wikidata": "string | null"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Notes:
+- `person.uid` is `null` for a brand-new person; the graph mints or matches by identifiers.
+- An empty `contributions` array means "remove all contributors".
+
+## Example message (anonymised)
+
+The list mixes an internal person (referenced by uid), an external person (referenced by a source
+identifier), and a brand-new person (`uid: null`):
+
+```json
+{
+  "id": "00000000-0000-0000-0000-000000000001",
+  "actionType": "UPDATE",
+  "targetType": "DOCUMENT",
+  "targetUid": "00000000-0000-0000-0000-0000000000aa",
+  "path": "contributions",
+  "personUid": "local-user1",
+  "application": "sovisuplus",
+  "timestamp": "2026-01-01T09:00:00.000Z",
+  "parameters": {
+    "contributions": [
+      {
+        "rank": null,
+        "roles": ["http://id.loc.gov/vocabulary/relators/aut"],
+        "person": {
+          "uid": "local-user1",
+          "lastName": "Doe",
+          "firstName": "Jane",
+          "displayName": "Jane Doe",
+          "identifiers": [
+            { "type": "orcid",     "value": "0000-0000-0000-0001" },
+            { "type": "local",     "value": "user1" },
+            { "type": "eppn",      "value": "user1@univ-example.fr" },
+            { "type": "hal_login", "value": "jdoe" },
+            { "type": "idhals",    "value": "jane-doe" }
+          ]
+        },
+        "affiliations": [
+          {
+            "hal": "1000001", "nns": null, "ror": null, "isni": null,
+            "name": "Example University - School of Law",
+            "type": "regrouplaboratory",
+            "idref": "100000001",
+            "label": "Example University - School of Law [EU SL]",
+            "acronym": "EU SL", "wikidata": null
+          },
+          {
+            "hal": "1000002", "nns": null, "ror": null, "isni": null,
+            "name": "Example Health Research Department",
+            "type": "institution",
+            "idref": null,
+            "label": "Example Health Research Department [EHRD]",
+            "acronym": "EHRD", "wikidata": null
+          }
+        ]
+      },
+      {
+        "rank": null,
+        "roles": ["http://id.loc.gov/vocabulary/relators/aui"],
+        "person": {
+          "uid": "sudoc-http://www.idref.fr/000000000/id",
+          "lastName": null,
+          "firstName": null,
+          "displayName": "Martin, Paul (19..-....)",
+          "identifiers": [
+            { "type": "idref", "value": "000000000" }
+          ]
+        },
+        "affiliations": []
+      },
+      {
+        "rank": null,
+        "roles": ["http://id.loc.gov/vocabulary/relators/ctb"],
+        "person": {
+          "uid": null,
+          "lastName": "Durand",
+          "firstName": "Claire",
+          "displayName": "Claire Durand",
+          "identifiers": [
+            { "type": "orcid", "value": "0000-0000-0000-0002" }
+          ]
+        },
+        "affiliations": [
+          {
+            "hal": "1000003", "nns": null, "ror": null, "isni": null,
+            "name": "Example Institute",
+            "type": "institution",
+            "idref": null,
+            "label": "Example Institute [EI]",
+            "acronym": "EI", "wikidata": null
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Integration logic (graph processing)
+
+The message is decoded into a `Change` (`target_type=DOCUMENT`, `path=contributions`,
+`action_type=UPDATE`, full list in `parameters`), persisted, then applied with **replace
+semantics**: the document's contributions are reconciled to exactly the submitted list. The pieces
+below are adapted from the per-action rules described in the issue, re-expressed for the full-state
+message.
+
+> New routing required: `ChangeProcessorFactory` currently handles `path` values `subjects`,
+> `documentType`, `titles`, `abstracts`, and `action_type == "MERGE"` — there is **no**
+> `contributions` branch. A new `DocumentContributionsChangeProcessor` must be created and registered
+> in `ChangeProcessorFactory.get_processor` for `path == "contributions"`.
+
+### Reconciliation (replace semantics)
+
+For the target document, compute the desired contribution set from `parameters.contributions` and:
+
+- create a `Contribution` for a person not yet contributing to the document;
+- update the existing `Contribution` for a person already contributing;
+- delete any existing `Contribution` of the document whose person is **absent** from the submitted
+  list (the same effect as the per-action `REMOVE`).
+
+The graph already has the building blocks used by the source-driven path
+(`SourceContributorMappingService._update_contributions` →
+`document_dao.create_contribution` + `document_dao.delete_contributions_not_in`); reuse the same
+DAO operations rather than introducing a parallel mechanism.
+
+### Person resolution (per contribution)
+
+For each `contribution.person`:
+
+- If `person.uid` is provided, use that existing `Person` node.
+- If `person.uid` is `null`, match against existing persons by the provided `identifiers`; create a
+  new **external** person if no match is found. A null-uid person may match **either** an external or
+  an internal person — if it matches an internal person, resolve to that internal person (and the
+  internal-person identifier/name freeze rule below then applies).
+
+**Matching rules differ by person kind** because of how identifiers are currently stored in the
+graph (see the model note below):
+
+- **External persons** (`external: True`) are matched on their **source person identifiers**: find a
+  person whose `SourcePersonIdentifier`s are *at least partially* compatible with the incoming
+  `identifiers`.
+- **Internal persons** (`external: False`) carry `AgentIdentifier`s and are matched on those.
+
+When the incoming identifiers point to **two or more different `Person` nodes**, choose by **name
+similarity** between the candidate persons and the submitted person name (reuse the existing
+name-distance helpers in `SourceContributorMappingService`). The identifier(s) that pointed to the
+**non-selected** person(s) are **unusable**: discard them — never write an identifier onto a person
+it does not consistently belong to. **Do not add inconsistent identifiers to the graph.**
+
+> Gap: no existing query does this. `person_dao.find_by_identifiers` /
+> `find_person_by_identifiers.cypher` match **only** `AgentIdentifier`, return the **first** hit
+> (`LIMIT 1`), and perform no conflict detection or disambiguation. External persons reach their
+> source identifiers via `Person-[:RECORDED_BY]->SourcePerson-[:HAS_IDENTIFIER]->SourcePersonIdentifier`
+> — a path that query never traverses. New matching logic/queries are required to: (a) match external
+> persons through their `SourcePersonIdentifier`s with *partial* compatibility, (b) match internal
+> persons through `AgentIdentifier`s, (c) return **all** candidate persons (not just the first) so the
+> name-similarity tie-break and unusable-identifier discard can run.
+
+### Identifier & name updates — internal vs external
+
+This is governed by the current identifier model:
+
+> Today, only **source** people carry identifiers (`SourcePersonIdentifier`). The graph does **not**
+> compute "true" `AgentIdentifier`s from source people. `AgentIdentifier`s exist only on **internal**
+> people. Because nothing else writes `AgentIdentifier`s on external people, this action may safely
+> create them there without any concurrent-writer conflict.
+
+- **Internal persons** (`external: False`): identifiers are **immutable** here. sovisuplus is **not**
+  allowed to edit internal-people identifiers — **enforce this**: ignore the incoming
+  `person.identifiers` entirely (no add / update / remove of `AgentIdentifier`s), and do not modify
+  the internal person's `PersonName`. Only the **contribution** (roles, rank, affiliations) is
+  written for an internal contributor.
+- **External persons** (`external: True`): create missing `AgentIdentifier` nodes from the incoming
+  `identifiers` and link them via `HAS_IDENTIFIER` — but only the **consistent** ones (any identifier
+  discarded by the name-similarity disambiguation above must not be written). The external person's
+  `display_name` may be set from the submitted name.
+
+> Rationale: affiliations are a property of the *contribution* (the signature at publication time),
+> not the person's current memberships — an internal author may have been affiliated elsewhere when
+> the document was published, or list extra affiliations in their signature. Affiliations evolve over
+> time; identifiers do not. Hence affiliations are always updatable, while internal-person
+> identifiers are frozen.
+
+### Contribution content
+
+Each `Contribution` stores:
+
+- `roles` — the LoC relator URIs from `contribution.roles`;
+- `rank` — when a non-null rank is provided.
+
+> Gap: `document_dao.create_contribution` and `create_contribution_to_document.cypher` currently set
+> only `roles` (no `rank`). Storing `rank` requires extending that DAO method and query (and
+> confirming the merged `Contribution` is meant to carry a `rank` property).
+
+### Affiliation resolution
+
+Affiliations carry authority identifiers (`hal`, `idref`, `ror`, `isni`, `nns`, `wikidata`) plus
+`name` / `label` / `acronym` / `type`. They must be linked to `AuthorityOrganizationState` or
+`AuthorityOrganizationRoot` using the **existing affiliation resolution algorithm** — no new
+mechanism, and no duplicate `AuthorityOrganizationState` / `AuthorityOrganizationRoot` when matching
+identifiers already exist. Affiliations are updatable for **both** internal and external persons.
+
+**Resolve in-memory; do not persist anything in the source layer.** The existing harvested path
+calls `SourceOrganizationService.get_cluster(uid)` to assemble a cluster of persisted
+`SourceOrganization` nodes before resolving — but that step is only *input preparation*. The
+resolution algorithm itself, `AuthorityOrganizationService.get_or_create_authority_organization`,
+accepts a `List[SourceOrganization]` of **in-memory** objects and never reads `SourceOrganization`
+nodes from the graph; de-duplication happens one layer down in
+`_get_or_create_state_in_graph_by_identifier` → `get_states_with_compatible_identifiers`, which
+matches against existing `AuthorityOrganizationState`s **by identifier**. No `SourceOrganization`
+node is required for that guarantee.
+
+Do **not** create `SourceOrganization` nodes for message affiliations, and do **not** fabricate a
+`SourceContribution`/`SourceRecord` to host them:
+- a `SourceContribution` only exists under a harvested `SourceRecord` (`create_source_contribution`
+  `MATCH`es a `SourceRecord`); a user edit has none, so a persisted `SourceOrganization` would be an
+  orphan and a fabricated source record would invent fake harvest provenance.
+- the message already carries every authority identifier inline, so the "cluster" is simply the
+  in-memory list — there is nothing to discover via `get_cluster`.
+
+Per contribution:
+
+1. Build **in-memory** `SourceOrganization` objects from `contribution.affiliations`:
+   - `source = HAL`, `source_identifier = affiliation.hal` → uid `hal-<hal>` (matches how harvested
+     HAL source orgs are keyed, so resolution converges on the same authority as the harvested one);
+   - `name = affiliation.name` (fall back to `label`);
+   - `type` mapped from the message `type` (`"institution"`, `"regrouplaboratory"`, …) onto
+     `SourceOrganization.SourceOrganisationType`, defaulting to `ORGANIZATION` when unmapped;
+   - `identifiers` = the non-null id fields (`idref`, `ror`, `isni`, `nns`, `wikidata`) as
+     `SourceOrganizationIdentifier`s.
+   - Defensive: if `affiliation.hal` is null (should not happen given the HAL autocomplete), fall back
+     to another identifier as the source key, or skip the affiliation — never mint a uid with an
+     empty source identifier.
+2. `AuthorityOrganizationService.get_or_create_authority_organization(in_memory_orgs)` — resolves the
+   list (by identifiers, else normalized name) to an `AuthorityOrganizationRoot` with its states,
+   matching/merging existing authorities by identifier and creating them only when absent.
+3. `SourceContributorMappingService._elect_authority_organizations_for_affiliation_statements(...)` —
+   elects one target per root (a unique matching state, else the root).
+4. `document_dao.update_contribution_affiliation_statements(contribution_id, targets)` — attaches the
+   elected authority targets to the contribution.
+
+The resolution/election logic itself must not be reimplemented. Note (harmless): resolved
+`AuthorityOrganizationState.source_organization_uids` will record the `hal-<hal>` uids even though no
+such `SourceOrganization` node exists — that is tracking metadata on the authority, not a dangling
+graph edge.
+
+### Entities left untouched on removal
+
+Removing a contribution removes only the authorship relationship for this document. It must **not**
+delete: `Person`, `PersonName`, `AgentIdentifier`, `AuthorityOrganizationState`,
+`AuthorityOrganizationRoot`, or the `Document`.
+
+---
+
+## Supersession — only the latest contributions change is applied
+
+A document accumulates one `Change` per save, so several `path=contributions` changes can pile up
+over time. They are **full-state** snapshots, so only the **most recent** one is meaningful — it
+already describes the complete desired contributor set; replaying the older ones is redundant and,
+if applied out of timestamp order, could even produce a wrong transient state.
+
+Rule: among the stored `path=contributions` changes for a document, **only the latest** (by
+`timestamp`, tie-broken by uid) is applied — both at interactive time (it is newest by definition)
+and on replay. Older contributions changes are **superseded**.
+
+- **Do not delete** superseded changes. They are retained for a forthcoming sovisuplus feature that
+  displays the document's modification history.
+- **"Latest" is computed lazily**, at apply/replay time — by selecting the maximum-`timestamp`
+  `path=contributions` change for the document. Superseded changes are **not** mutated or tagged: no
+  `superseded` status is written, no extra writes when a new change arrives. The newest is simply
+  chosen at read time; the older ones remain untouched in the graph as history.
+- `ChangeService.apply_changes_to_node` (the replay path) must therefore, for the `contributions`
+  path, select and apply **only** the most recent contributions change and **skip** the rest —
+  rather than its current behaviour of replaying every stored change for the target. Changes on other
+  paths (subjects, titles, abstracts, …) are unaffected by this rule and keep being applied as today.
+
+## After applying the change
+
+- The change is **persisted immediately** as a graph modification (not a temporary state) and must
+  be **replayable** idempotently after a remerge via `apply_changes_to_node`.
+- **No separate document recomputation is triggered** by this action. User actions are already
+  reapplied at the end of a document recompute; recomputing again here would be redundant. The
+  action only reconciles contributions and then signals the update.
+- **Intended consequence — user edits pin the contributor list against future harvests.** Because the
+  saved change is replayed (full-replace) after every recompute, a saved contributor list
+  **overrides** source-derived contributions on each subsequent recompute: co-authors newly
+  discovered by later harvesting will **not** appear until the user saves again. This follows directly
+  from the full-state replace + replay design and is the accepted behaviour, not a bug.
+- A single **"document updated"** event is emitted once the whole message has been applied (reuse the
+  existing `document_updated` signal / outbound document-updated message — there is **no** dedicated
+  "confirmation" message type). The payload does not need to carry the complete document; sovisuplus
+  re-queries the GraphQL API to resync.
+
+### Outbound `MessageMode` is set by the trigger context
+
+The mode of the "document updated" event is decided by **how the change is being applied**, not by
+the change itself:
+
+- **Applied as it just arrived from sovisuplus** (the AMQP user-action is processed directly) →
+  emit with `MessageMode.INTERACTIVE` → **interactive** queue.
+- **Replayed during a recomputation from source records** (`apply_changes_to_node` after a remerge /
+  harvesting) → emit with `MessageMode.BATCH` → **batch** queue.
+
+The change content and graph effect are identical in both contexts; only the outbound queue differs.
+
+> Implementation note: `ChangeService.apply_change` currently hardcodes
+> `document_updated.send_async(..., mode=MessageMode.INTERACTIVE)`. That is correct only for the
+> direct-from-AMQP path. The mode must be **threaded through** the apply path so that
+> `apply_changes_to_node` (the replay path, invoked from document recompute) emits
+> `MessageMode.BATCH` instead. Do not leave the mode hardcoded.

--- a/tests/test_amqp/test_amqp_interface.py
+++ b/tests/test_amqp/test_amqp_interface.py
@@ -19,6 +19,7 @@ async def test_amqp_connect(mock_connect):
     assert mock_connect.call_args[0][
                0] == "amqp://rabbitmq_test_user:rabbitmq_test_password@rabbitmq_test_host/"
     assert amqp_interface.pika_channel.set_qos.called
-    assert amqp_interface.pika_channel.declare_exchange.call_count == 4
+    # 3 exchanges (graph, publications, directory), each declared with its dead-letter exchange
+    assert amqp_interface.pika_channel.declare_exchange.call_count == 6
     assert [key in amqp_interface.pika_exchanges for key in
             ["people", "structures", "publications"]]

--- a/tests/test_services/test_contribution_update_service.py
+++ b/tests/test_services/test_contribution_update_service.py
@@ -1,0 +1,260 @@
+# file: tests/test_services/test_contribution_update_service.py
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from app.amqp.message_mode import MessageMode
+from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
+from app.graph.neo4j.neo4j_connexion import Neo4jConnexion
+from app.models.change import Change, TargetType, ChangeStatus
+from app.models.document import Document
+from app.models.people import Person
+from app.services.changes.change_processor_factory import ChangeProcessorFactory
+from app.services.changes.change_service import ChangeService
+from app.services.changes.processors.document_contributions_change_processor import \
+    DocumentContributionsChangeProcessor
+
+AUT = "http://id.loc.gov/vocabulary/relators/aut"
+CTB = "http://id.loc.gov/vocabulary/relators/ctb"
+
+
+@pytest.fixture(name="mocked_document_updated_signal")
+def mocked_document_updated_signal_fixture():
+    """Mock the `document_updated` signal."""
+    with patch("app.signals.document_updated.send_async", new_callable=AsyncMock) as mocked_signal:
+        yield mocked_signal
+
+
+def _contributions_change(document_uid: str, contributions: list[dict],
+                          uid: str = "sovisuplus:c1",
+                          change_id: str = "c1",
+                          timestamp: str = "2026-01-01T09:00:00Z") -> Change:
+    return Change(
+        uid=uid,
+        target_uid=document_uid,
+        target_type=TargetType.DOCUMENT,
+        person_uid="local-user1",
+        application="sovisuplus",
+        id=change_id,
+        action_type="UPDATE",
+        path="contributions",
+        parameters={"contributions": contributions},
+        timestamp=timestamp,
+    )
+
+
+async def _contributor_uids(document_uid: str) -> set:
+    document_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Document)
+    document = await document_dao.get_document_by_uid(document_uid)
+    return {contribution.contributor.uid for contribution in document.contributions}
+
+
+async def _count_affiliation_statements(document_uid: str) -> int:
+    query = (
+        "MATCH (:Document {uid: $uid})-[:HAS_CONTRIBUTION]->(:Contribution)"
+        "-[r:HAS_AFFILIATION_STATEMENT]->(:AuthorityOrganization) RETURN count(r) AS n"
+    )
+    async with Neo4jConnexion().get_driver() as driver:
+        async with driver.session() as session:
+            result = await session.run(query, uid=document_uid)
+            record = await result.single()
+            return record["n"]
+
+
+def test_factory_routes_contributions_to_processor() -> None:
+    """The factory routes a path=contributions document change to the new processor."""
+    change = _contributions_change("doc-1", [])
+    processor = ChangeProcessorFactory.get_processor(change)
+    assert isinstance(processor, DocumentContributionsChangeProcessor)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_replaces_contributions(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        persisted_person_a_pydantic_model: Person,
+        mocked_document_updated_signal) -> None:
+    """
+    Given a persisted document and an internal person,
+    When a full-state contributions change is applied with the internal person (by uid),
+        a brand-new external person (uid null) and an affiliation,
+    Then the document's contributors are exactly the submitted ones and affiliations are linked.
+    """
+    document = document_hal_article_a_persisted_model
+    internal = persisted_person_a_pydantic_model
+
+    contributions = [
+        {
+            "rank": 0,
+            "roles": [AUT],
+            "person": {"uid": internal.uid, "displayName": internal.display_name,
+                       "identifiers": []},
+            "affiliations": [
+                {"hal": "1000001", "idref": "100000001", "ror": None, "isni": None,
+                 "nns": None, "wikidata": None, "name": "Example University",
+                 "label": "Example University [EU]", "acronym": "EU", "type": "institution"}
+            ],
+        },
+        {
+            "rank": 1,
+            "roles": [CTB],
+            "person": {"uid": None, "displayName": "Claire Durand",
+                       "firstName": "Claire", "lastName": "Durand",
+                       "identifiers": [{"type": "orcid", "value": "0000-0000-0000-0002"}]},
+            "affiliations": [],
+        },
+    ]
+    change = _contributions_change(document.uid, contributions)
+
+    await ChangeService().create_and_apply_change(change)
+
+    contributor_uids = await _contributor_uids(document.uid)
+    assert internal.uid in contributor_uids
+    assert "orcid-0000-0000-0000-0002" in contributor_uids
+    assert len(contributor_uids) == 2
+    assert await _count_affiliation_statements(document.uid) >= 1
+
+    mocked_document_updated_signal.assert_called_once()
+    assert mocked_document_updated_signal.call_args.kwargs == {
+        "document_uid": document.uid, "mode": MessageMode.INTERACTIVE}
+
+
+@pytest.mark.asyncio
+async def test_empty_list_removes_all_contributors(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        mocked_document_updated_signal) -> None:  # pylint: disable=unused-argument
+    """An empty contributions list removes all the document's contributors."""
+    document = document_hal_article_a_persisted_model
+    change = _contributions_change(document.uid, [])
+
+    await ChangeService().create_and_apply_change(change)
+
+    assert await _contributor_uids(document.uid) == set()
+
+
+@pytest.mark.asyncio
+async def test_internal_person_identifiers_are_frozen(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        persisted_person_a_pydantic_model: Person,
+        mocked_document_updated_signal) -> None:  # pylint: disable=unused-argument
+    """
+    Incoming identifiers for an internal person are ignored (frozen): no AgentIdentifier added.
+    """
+    document = document_hal_article_a_persisted_model
+    internal = persisted_person_a_pydantic_model
+    person_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Person)
+    before = {(i.type.value, i.value) for i in (await person_dao.get(internal.uid)).identifiers}
+
+    contributions = [{
+        "rank": 0,
+        "roles": [AUT],
+        "person": {"uid": internal.uid, "displayName": internal.display_name,
+                   "identifiers": [{"type": "idref", "value": "999999999"}]},
+        "affiliations": [],
+    }]
+    await ChangeService().create_and_apply_change(
+        _contributions_change(document.uid, contributions))
+
+    after = {(i.type.value, i.value) for i in (await person_dao.get(internal.uid)).identifiers}
+    assert after == before
+    assert ("idref", "999999999") not in after
+
+
+@pytest.mark.asyncio
+async def test_supersession_only_latest_contributions_change_replayed(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        persisted_person_a_pydantic_model: Person,
+        mocked_document_updated_signal) -> None:  # pylint: disable=unused-argument
+    """
+    On replay, only the latest contributions change is applied; older ones are kept but skipped.
+    """
+    document = document_hal_article_a_persisted_model
+    internal = persisted_person_a_pydantic_model
+    change_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Change)
+
+    older = _contributions_change(
+        document.uid,
+        [{"rank": 0, "roles": [AUT],
+          "person": {"uid": internal.uid, "displayName": internal.display_name,
+                     "identifiers": []},
+          "affiliations": []}],
+        uid="sovisuplus:old", change_id="old", timestamp="2026-01-01T08:00:00Z")
+    newer = _contributions_change(
+        document.uid,
+        [{"rank": 0, "roles": [AUT],
+          "person": {"uid": internal.uid, "displayName": internal.display_name,
+                     "identifiers": []},
+          "affiliations": []}],
+        uid="sovisuplus:new", change_id="new", timestamp="2026-01-02T08:00:00Z")
+    await change_dao.create_document_change(document, older)
+    await change_dao.create_document_change(document, newer)
+
+    await ChangeService().apply_changes_to_node(document.uid, mode=MessageMode.BATCH)
+
+    assert (await change_dao.get_by_uid("sovisuplus:new")).status == ChangeStatus.APPLIED
+    # older change is superseded: not applied, but preserved in the graph
+    stored_older = await change_dao.get_by_uid("sovisuplus:old")
+    assert stored_older is not None
+    assert stored_older.status == ChangeStatus.CREATED
+
+
+@pytest.mark.asyncio
+async def test_reconcile_resolves_existing_external_person_by_uid(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        mocked_document_updated_signal) -> None:  # pylint: disable=unused-argument
+    """
+    An existing external person (display_name only, no PersonName) referenced by uid is
+    resolved without a hydration failure (regression: _hydrate dropped display_name).
+    """
+    document = document_hal_article_a_persisted_model
+    person_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Person)
+    external = Person(uid="orcid-0000-0002-7428-4208", display_name="Bernard Chevalier",
+                      external=True,
+                      identifiers=[{"type": "orcid", "value": "0000-0002-7428-4208"}])
+    await person_dao.create(external)
+
+    # get() must hydrate the external person without raising
+    hydrated = await person_dao.get(external.uid)
+    assert hydrated is not None
+    assert hydrated.display_name == "Bernard Chevalier"
+    assert hydrated.external is True
+
+    contributions = [{
+        "rank": 1, "roles": [CTB],
+        "person": {"uid": external.uid, "displayName": "Bernard Chevalier",
+                   "firstName": None, "lastName": None,
+                   "identifiers": [{"type": "orcid", "value": "0000-0002-7428-4208"}]},
+        "affiliations": [],
+    }]
+    await ChangeService().create_and_apply_change(
+        _contributions_change(document.uid, contributions))
+
+    assert external.uid in await _contributor_uids(document.uid)
+
+
+@pytest.mark.asyncio
+async def test_replay_emits_batch_mode(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        persisted_person_a_pydantic_model: Person,
+        mocked_document_updated_signal) -> None:
+    """Replaying a contributions change via apply_changes_to_node emits BATCH mode."""
+    document = document_hal_article_a_persisted_model
+    internal = persisted_person_a_pydantic_model
+    change_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Change)
+    change = _contributions_change(
+        document.uid,
+        [{"rank": 0, "roles": [AUT],
+          "person": {"uid": internal.uid, "displayName": internal.display_name,
+                     "identifiers": []},
+          "affiliations": []}])
+    await change_dao.create_document_change(document, change)
+
+    await ChangeService().apply_changes_to_node(document.uid, mode=MessageMode.BATCH)
+
+    assert mocked_document_updated_signal.call_args is not None
+    assert mocked_document_updated_signal.call_args.kwargs["mode"] == MessageMode.BATCH


### PR DESCRIPTION
…plus

- reconcile document contributions (replace semantics) via new Change processor
- resolve internal/external persons; in-memory affiliation resolution
- thread interactive/batch mode; supersede older contributions changes on replay
- fix PersonDAO._hydrate to restore display_name/external (external person get())