### PR TITLE
fix: prevent internal/external author AgentIdentifier collision

### DIFF
--- a/app/commands/people.py
+++ b/app/commands/people.py
@@ -177,6 +177,44 @@ def resave_people_all():
 
 
 @people_cli.command()
+def clear_shared_identifiers(
+        apply: bool = typer.Option(
+            False,
+            "--apply",
+            help="Actually detach the shared identifier edges. Without it, only report them."
+        )
+):
+    """
+    Clear AgentIdentifiers wrongly shared between an external and an internal person.
+
+    Lists every AgentIdentifier owned by both an external and an internal person and, with
+    --apply, detaches the external person's HAS_IDENTIFIER edge (the AgentIdentifier node and
+    the external Person are left intact), restoring one-owner-per-identifier.
+    """
+
+    @with_app_lifecycle
+    async def _clear_shared_identifiers():
+        service = PeopleService()
+        shared = await service.find_external_internal_shared_identifiers()
+        if not shared:
+            typer.echo("No AgentIdentifier shared between external and internal persons.")
+            return
+        typer.echo(f"{len(shared)} shared identifier(s) found:")
+        for row in shared:
+            typer.echo(
+                f"  {row['id_type']}={row['id_value']} | "
+                f"external {row['external_uid']} ({row['external_display_name']}) "
+                f"-> internal {row['internal_uid']} ({row['internal_display_name']})")
+        if not apply:
+            typer.echo("Dry run: re-run with --apply to detach the external edges.")
+            return
+        detached = await service.detach_external_shared_identifiers()
+        typer.echo(f"Detached {detached} external HAS_IDENTIFIER edge(s).")
+
+    asyncio.run(_clear_shared_identifiers())
+
+
+@people_cli.command()
 def resave_person(
         uid: str = typer.Argument(..., help="The UID of the person")
 ):

--- a/app/graph/neo4j/person_dao.py
+++ b/app/graph/neo4j/person_dao.py
@@ -448,7 +448,9 @@ class PersonDAO(Neo4jDAO):
         disambiguate between several persons and discard inconsistent identifiers.
 
         :param identifiers: List of dictionaries with 'type' and 'value'.
-        :return: list of dicts with keys id_type, id_value, person_uid, external, display_name.
+        :return: list of dicts with keys id_type, id_value, person_uid, external, display_name,
+            via ('agent' when matched through an AgentIdentifier, 'source' when matched through a
+            SourcePersonIdentifier).
         """
         if not identifiers:
             return []
@@ -492,6 +494,43 @@ class PersonDAO(Neo4jDAO):
         """
         query = load_query("create_person_identifiers")
         await tx.run(query, person_uid=person_uid, identifiers=identifiers)
+
+    async def find_external_internal_shared_identifiers(self) -> list[dict]:
+        """
+        Find every AgentIdentifier shared between an external and an internal person.
+
+        :return: list of dicts with keys external_uid, external_display_name, id_type, id_value,
+            internal_uid, internal_display_name (one row per shared identifier / internal owner).
+        """
+        async with Neo4jConnexion().get_driver() as driver:
+            async with driver.session() as session:
+                result = await session.run(
+                    load_query("find_external_internal_shared_identifiers"))
+                return await result.data()
+
+    async def detach_external_shared_identifiers(self) -> int:
+        """
+        Detach, from external persons, every HAS_IDENTIFIER edge whose AgentIdentifier is also
+        owned by an internal person. The AgentIdentifier node and the external Person are left
+        intact.
+
+        :return: number of HAS_IDENTIFIER relationships detached.
+        """
+        async with Neo4jConnexion().get_driver() as driver:
+            async with driver.session() as session:
+                return await session.write_transaction(
+                    self._detach_external_shared_identifiers_transaction)
+
+    @staticmethod
+    async def _detach_external_shared_identifiers_transaction(
+            tx: AsyncManagedTransaction
+    ) -> int:
+        """
+        Transaction backing :meth:`detach_external_shared_identifiers`.
+        """
+        result = await tx.run(load_query("detach_external_shared_identifiers"))
+        record = await result.single()
+        return record["detached"] if record else 0
 
     @staticmethod
     def _hydrate(record) -> Person:

--- a/app/graph/neo4j/queries/detach_external_shared_identifiers.cypher
+++ b/app/graph/neo4j/queries/detach_external_shared_identifiers.cypher
@@ -1,0 +1,10 @@
+// Detach, from external persons, every HAS_IDENTIFIER edge whose AgentIdentifier is also owned
+// by an internal person, restoring one-owner-per-identifier. The AgentIdentifier node and the
+// external Person are left intact.
+MATCH (ext:Person {external: true})-[r:HAS_IDENTIFIER]->(ai:AgentIdentifier)
+WHERE EXISTS {
+  MATCH (:Person {external: false})-[:HAS_IDENTIFIER]->(ai)
+}
+WITH DISTINCT r
+DELETE r
+RETURN count(r) AS detached

--- a/app/graph/neo4j/queries/find_external_internal_shared_identifiers.cypher
+++ b/app/graph/neo4j/queries/find_external_internal_shared_identifiers.cypher
@@ -1,0 +1,9 @@
+MATCH (ext:Person {external: true})-[:HAS_IDENTIFIER]->(ai:AgentIdentifier)
+      <-[:HAS_IDENTIFIER]-(int:Person {external: false})
+RETURN ext.uid AS external_uid,
+       ext.display_name AS external_display_name,
+       ai.type AS id_type,
+       ai.value AS id_value,
+       int.uid AS internal_uid,
+       int.display_name AS internal_display_name
+ORDER BY external_uid, id_type, id_value

--- a/app/graph/neo4j/queries/find_person_candidates_by_identifiers.cypher
+++ b/app/graph/neo4j/queries/find_person_candidates_by_identifiers.cypher
@@ -2,15 +2,16 @@ UNWIND $identifiers AS identifier
 CALL {
   WITH identifier
   MATCH (p:Person)-[:HAS_IDENTIFIER]->(:AgentIdentifier {type: identifier.type, value: identifier.value})
-  RETURN p
+  RETURN p, 'agent' AS via
   UNION
   WITH identifier
   MATCH (p:Person)-[:RECORDED_BY]->(:SourcePerson)-[:HAS_IDENTIFIER]->(:SourcePersonIdentifier {type: identifier.type, value: identifier.value})
-  RETURN p
+  RETURN p, 'source' AS via
 }
 RETURN DISTINCT
   identifier.type AS id_type,
   identifier.value AS id_value,
   p.uid AS person_uid,
   p.external AS external,
-  p.display_name AS display_name
+  p.display_name AS display_name,
+  via

--- a/app/services/contributions/contribution_update_service.py
+++ b/app/services/contributions/contribution_update_service.py
@@ -91,10 +91,26 @@ class ContributionUpdateService:
         """
         Resolve the contribution's person to a graph Person uid, creating a new external
         person when necessary, and applying the internal/external identifier policy.
+
+        An incoming identifier already owned by an existing person through an ``AgentIdentifier``
+        is authoritative: the contribution is re-pointed onto that owner (internal owners win
+        over external ones) rather than copying the identifier onto a second person and creating
+        a shared node.
         """
         uid = person.get("uid")
         incoming_identifiers = self._incoming_identifiers(person)
         display_name = person.get("displayName") or person.get("display_name")
+
+        candidates = await self._person_dao().find_candidates_by_identifiers(incoming_identifiers)
+
+        # Authoritative re-point: a person that owns an incoming identifier via AgentIdentifier.
+        owner = self._select_agent_owner(candidates, display_name)
+        if owner is not None:
+            owner_uid, owner_external = owner
+            await self._apply_identifier_policy(
+                owner_uid, owner_external, incoming_identifiers,
+                self._agent_inconsistent_keys(candidates, owner_uid))
+            return owner_uid
 
         if uid:
             existing = await self._person_dao().get(uid)
@@ -105,13 +121,17 @@ class ContributionUpdateService:
             # uid provided but not found: fall back to matching/creation
             logger.info("Person uid %s not found, falling back to identifier matching", uid)
 
-        return await self._match_or_create_person(incoming_identifiers, display_name)
+        return await self._match_or_create_person(
+            candidates, incoming_identifiers, display_name)
 
     async def _match_or_create_person(
-            self, incoming_identifiers: list[dict], display_name: Optional[str]
+            self, candidates: list[dict], incoming_identifiers: list[dict],
+            display_name: Optional[str]
     ) -> Optional[str]:
-        candidates = await self._person_dao().find_candidates_by_identifiers(incoming_identifiers)
-
+        """
+        Match the person against source-identifier candidates (AgentIdentifier owners are
+        handled earlier by re-pointing), else create a new external person.
+        """
         persons: dict[str, dict] = {}
         id_to_persons: dict[tuple, set] = defaultdict(set)
         for row in candidates:
@@ -134,6 +154,47 @@ class ContributionUpdateService:
             selected, bool(persons[selected]["external"]), incoming_identifiers,
             self._inconsistent_identifier_keys(id_to_persons, selected))
         return selected
+
+    @classmethod
+    def _select_agent_owner(
+            cls, candidates: list[dict], submitted_name: Optional[str]
+    ) -> Optional[tuple]:
+        """
+        Among the candidates that own an incoming identifier through an ``AgentIdentifier``,
+        pick the one to re-point onto: internal persons take precedence over external ones,
+        ties broken by name similarity. Returns ``(uid, external)`` or ``None`` when no
+        candidate owns an incoming identifier via an AgentIdentifier.
+        """
+        agent_persons: dict[str, dict] = {}
+        for row in candidates:
+            if row.get("via") != "agent":
+                continue
+            agent_persons[row["person_uid"]] = {
+                "external": bool(row.get("external")),
+                "display_name": row.get("display_name"),
+            }
+        if not agent_persons:
+            return None
+        internal = [uid for uid, data in agent_persons.items() if not data["external"]]
+        pool = internal or list(agent_persons.keys())
+        if len(pool) == 1:
+            selected = pool[0]
+        else:
+            selected = cls._select_by_name_similarity(pool, agent_persons, submitted_name)
+        return selected, agent_persons[selected]["external"]
+
+    @classmethod
+    def _agent_inconsistent_keys(cls, candidates: list[dict], selected: str) -> set:
+        """
+        AgentIdentifier (type, value) keys owned by a person other than the selected one; these
+        must not be written onto the selected person.
+        """
+        id_to_persons: dict[tuple, set] = defaultdict(set)
+        for row in candidates:
+            if row.get("via") != "agent":
+                continue
+            id_to_persons[(row["id_type"], row["id_value"])].add(row["person_uid"])
+        return cls._inconsistent_identifier_keys(id_to_persons, selected)
 
     @staticmethod
     def _inconsistent_identifier_keys(id_to_persons: dict[tuple, set], selected: str) -> set:

--- a/app/services/people/people_service.py
+++ b/app/services/people/people_service.py
@@ -152,6 +152,28 @@ class PeopleService:
         dao: PersonDAO = cast(PersonDAO, factory.get_dao(Person))
         return await dao.get_all_uids(external=external)
 
+    async def find_external_internal_shared_identifiers(self) -> list[dict]:
+        """
+        List every AgentIdentifier shared between an external and an internal person.
+
+        :return: list of dicts (external_uid, external_display_name, id_type, id_value,
+            internal_uid, internal_display_name).
+        """
+        factory = self._get_dao_factory()
+        dao: PersonDAO = cast(PersonDAO, factory.get_dao(Person))
+        return await dao.find_external_internal_shared_identifiers()
+
+    async def detach_external_shared_identifiers(self) -> int:
+        """
+        Detach, from external persons, every HAS_IDENTIFIER edge whose AgentIdentifier is also
+        owned by an internal person, restoring one-owner-per-identifier.
+
+        :return: number of HAS_IDENTIFIER relationships detached.
+        """
+        factory = self._get_dao_factory()
+        dao: PersonDAO = cast(PersonDAO, factory.get_dao(Person))
+        return await dao.detach_external_shared_identifiers()
+
     async def authenticate_identifier(self, person_uid: str,
                                       identifier_type: str, received_identifier: str,
                                       timestamp: str):

--- a/specs/fix-internal-external-author-identifier-collision/prompt.md
+++ b/specs/fix-internal-external-author-identifier-collision/prompt.md
@@ -1,0 +1,153 @@
+# Fix internal/external author identifier collision
+
+## Context
+
+A sovisuplus contribution-update message (see
+`specs/handle-contribution-update-message-from-sovisuplus#391/prompt.md`) carries, for each
+contributor, a `person` block with an `identifiers` list. For **external** persons these identifiers
+are minted as `AgentIdentifier` nodes by `ContributionUpdateService` — this is by design: a user
+performs a manual alignment in the sovisuplus *Authors* tab, and the resulting identifier
+(e.g. an `idhals`, `idref`, `orcid`) is attached to the external co-author.
+
+The problem appears when the **same identifier already belongs to an internal person**. Because an
+`AgentIdentifier` is a unique join key (composite uniqueness constraint on `(type, value)`), the
+graph holds **exactly one node** per `(type, value)`. Linking it to a second person does not create a
+new node — it adds a second `HAS_IDENTIFIER` edge to the *existing* node. The identifier then has two
+owners.
+
+### Observed case
+
+An external co-author **"Lamy, Jérôme"** (`scanr-anon:doi10.4000/chrhc.16724:lamy-jerome`,
+`external: True`) and the internal person **"Jerôme Lamy"** (`local-jelamy`, `external: False`) share
+three `AgentIdentifier` nodes:
+
+| type     | value                  |
+|----------|------------------------|
+| `idhals` | `jerome-lamy`          |
+| `idref`  | `116365803`            |
+| `orcid`  | `0000-0003-3820-284X`  |
+
+These are the same human. The alignment in sovisuplus is correct, but sovisuplus enforces that an
+identifier belongs to a single person, so when it tries to (re)assign `idhals=jerome-lamy` it is
+**refused — the identifier is already attributed to someone else** (the internal person, via the edge
+the graph wrongly created).
+
+### Root cause
+
+`ContributionUpdateService._resolve_person`
+(`app/services/contributions/contribution_update_service.py`) has two branches:
+
+- the **null-uid** branch (`_match_or_create_person`) computes `_inconsistent_identifier_keys` and
+  discards identifiers that point to a different person before writing;
+- the **uid-provided** branch (lines ~99–104) calls `_apply_identifier_policy(..., set())` with an
+  **empty** inconsistent-key set — i.e. **no conflict detection at all**.
+
+When a message references the external person by uid and carries the aligned identifiers, the uid
+branch writes *all* of them via `add_person_identifiers` → `create_person_identifiers.cypher`, which
+`MERGE`s each `AgentIdentifier` on `(type, value)`. The nodes already exist (owned by the internal
+person), so MERGE re-uses them and adds a second `HAS_IDENTIFIER` edge from the external person. That
+is the collision.
+
+> Note: external persons legitimately carry `AgentIdentifier`s (this is the #391 design). The bug is
+> **not** "external persons have identifiers" — it is "a single `AgentIdentifier` node is owned by two
+> different `Person` nodes." The invariant to enforce is one-owner-per-identifier.
+
+## Desired behaviour
+
+**An incoming identifier already owned by an existing person — via an `AgentIdentifier`, internal or
+external — means the contributor *is* that person.** Honour the alignment by resolving the
+contribution to the owning person, instead of copying the identifier onto a second person and creating
+a shared node.
+
+### Resolution rule (`_resolve_person`)
+
+For each contribution, regardless of whether `person.uid` is an external uid, an internal uid, or
+`null`:
+
+1. Look up the owners of the incoming identifiers (`find_candidates_by_identifiers` — already returns
+   all candidate persons with the matching identifier and their `external` flag).
+2. **If an incoming identifier is owned (via `AgentIdentifier`) by an existing person → re-point *this
+   contribution* to that owning person**, whether internal or external. The owning person — not the
+   uid carried in the message — becomes the contribution's person.
+   - **Precedence:** if both an internal and an external owner match, the **internal** person wins.
+   - **Tie-break:** among candidates of the selected kind, pick by name similarity between the
+     candidate and the submitted `displayName` (reuse `_select_by_name_similarity`).
+   - **Owner is internal** → apply the internal-person **freeze** policy: ignore the incoming
+     `identifiers` (no add / update / remove of `AgentIdentifier`s) and do **not** modify the internal
+     person's `PersonName`. Only the contribution (roles, rank, affiliations) is written.
+   - **Owner is external** → resolve to that external person and apply the normal external policy:
+     merge the **other consistent** incoming identifiers onto it (`MERGE`), `display_name` may be set
+     from the submitted name. This consolidates duplicate external co-authors onto one node instead of
+     spawning a new one.
+3. **Otherwise** (no `AgentIdentifier` owner) keep the current behaviour: resolve to the external
+   person (existing uid, or matched/created external person), and write only the **consistent**
+   incoming identifiers — any identifier owned by a *different* person is discarded
+   (`_inconsistent_identifier_keys`).
+
+> **Match on `AgentIdentifier` ownership, not on `SourcePersonIdentifier`.** Re-pointing is driven by
+> `AgentIdentifier`s only — those are authoritative, minted by a deliberate manual alignment. The
+> fuzzier `SourcePersonIdentifier` *partial-compatibility* match (used elsewhere to match external
+> persons) must **not** trigger a re-point: a weak harvested-source-id overlap between two genuinely
+> distinct external co-authors would otherwise collapse them onto the same contribution. Source-id
+> conflicts stay in the discard-on-conflict case (step 3).
+
+This makes conflict detection apply to **both** branches: the uid-provided branch must no longer pass
+an empty inconsistent-key set, and must re-point exactly like the null-uid branch.
+
+### Scope — strictly per-contribution
+
+- Do **not** merge or delete the external `Person` node. It remains a valid co-author signature on any
+  document where it has not been aligned.
+- Do **not** move the external person's other contributions.
+- Do **not** clean up orphaned external persons. If re-pointing leaves an external person with no
+  contributions, that is acceptable — orphan cleanup is out of scope.
+- The external person never receives an internal person's identifier (that is exactly what created the
+  collision).
+
+### Self-healing going forward
+
+Reconciliation is full-state / replace semantics, so no special migration is needed for *future*
+saves: the next time sovisuplus sends the contribution list for a document, `_resolve_person` returns
+the internal person, `document_dao.create_contribution` creates the internal contribution, and
+`document_dao.delete_contributions_not_in` drops the stale external one.
+
+## One-shot data cleanup — clear existing shared identifiers
+
+The code fix prevents *new* collisions but does not remove the `HAS_IDENTIFIER` edges already created.
+Provide a one-shot cleanup that **detaches every `AgentIdentifier` shared between an external and an
+internal person from the external person**, leaving it owned solely by the internal person.
+
+- Target: every `(:Person {external:true})-[r:HAS_IDENTIFIER]->(:AgentIdentifier)<-[:HAS_IDENTIFIER]-(:Person {external:false})`.
+  Delete the relationship `r` (the external person's edge). Do **not** delete the `AgentIdentifier`
+  node (the internal person still owns it) and do **not** delete the external `Person`.
+- This restores one-owner-per-identifier and lets sovisuplus re-assign the aligned identifier.
+- Existing contributions that still point at the external person are **not** re-pointed by the cleanup;
+  they will be corrected on the next sovisuplus save (replace semantics) per the rule above.
+- Identify-only first: the cleanup should report which `(external_person, identifier, internal_owner)`
+  triples it will change before applying, for auditability.
+
+> Currently exactly **one** external person is affected (the Lamy case, 3 shared identifiers), all of
+> the external↔internal kind, but the cleanup must sweep the general pattern, not hard-code that
+> person.
+
+> **External↔external shared nodes** (an `AgentIdentifier` owned by two *external* persons) do **not**
+> exist in the current data and are **out of scope** for the cleanup: there is no canonical owner to
+> keep, so detaching one side blindly is unsafe. Such cases (should any arise) are resolved by the
+> re-point rule on the next sovisuplus save, which consolidates onto a single external person.
+
+## Out of scope
+
+- Person merge / deduplication as a general facility (none exists; `EquivalenceService` is
+  source-record only).
+- Orphan-external-person deletion.
+- Any change to how external persons acquire identifiers in the non-colliding case (#391 behaviour is
+  correct).
+
+## Acceptance
+
+- A contribution-update message that carries an identifier owned by an internal person attaches the
+  contribution to the **internal** person; no identifier is written onto the external person; the
+  internal person's identifiers and name are untouched.
+- The uid-provided branch performs the same conflict detection as the null-uid branch.
+- After the one-shot cleanup, no `AgentIdentifier` node is linked to more than one `Person`.
+- The external `Person` node and its other contributions are left intact.

--- a/tests/test_services/test_contribution_update_service.py
+++ b/tests/test_services/test_contribution_update_service.py
@@ -13,6 +13,7 @@ from app.services.changes.change_processor_factory import ChangeProcessorFactory
 from app.services.changes.change_service import ChangeService
 from app.services.changes.processors.document_contributions_change_processor import \
     DocumentContributionsChangeProcessor
+from app.services.people.people_service import PeopleService
 
 AUT = "http://id.loc.gov/vocabulary/relators/aut"
 CTB = "http://id.loc.gov/vocabulary/relators/ctb"
@@ -234,6 +235,113 @@ async def test_reconcile_resolves_existing_external_person_by_uid(
         _contributions_change(document.uid, contributions))
 
     assert external.uid in await _contributor_uids(document.uid)
+
+
+@pytest.mark.asyncio
+async def test_repoints_to_internal_owner_of_aligned_identifier(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        persisted_person_a_pydantic_model: Person,
+        mocked_document_updated_signal) -> None:  # pylint: disable=unused-argument
+    """
+    A contribution referencing an external person by uid whose incoming identifier already
+    belongs (via AgentIdentifier) to an internal person re-points to the internal person, and
+    never copies that identifier onto the external person.
+    """
+    document = document_hal_article_a_persisted_model
+    internal = persisted_person_a_pydantic_model
+    person_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Person)
+    aligned = (await person_dao.get(internal.uid)).identifiers[0]
+    aligned_key = (aligned.type.value, aligned.value)
+
+    external = Person(uid="hal-ext-lamy", display_name="Lamy, Jerome",
+                      external=True, identifiers=[])
+    await person_dao.create(external)
+
+    contributions = [{
+        "rank": 0, "roles": [AUT],
+        "person": {"uid": external.uid, "displayName": "Lamy, Jerome",
+                   "identifiers": [{"type": aligned_key[0], "value": aligned_key[1]}]},
+        "affiliations": [],
+    }]
+    await ChangeService().create_and_apply_change(
+        _contributions_change(document.uid, contributions))
+
+    contributor_uids = await _contributor_uids(document.uid)
+    assert internal.uid in contributor_uids
+    assert external.uid not in contributor_uids
+
+    external_keys = {(i.type.value, i.value)
+                     for i in (await person_dao.get(external.uid)).identifiers}
+    assert aligned_key not in external_keys
+
+
+@pytest.mark.asyncio
+async def test_repoints_to_existing_external_owner(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        mocked_document_updated_signal) -> None:  # pylint: disable=unused-argument
+    """
+    A contribution whose incoming identifier already belongs (via AgentIdentifier) to an
+    existing external person consolidates onto that person instead of spawning a duplicate.
+    """
+    document = document_hal_article_a_persisted_model
+    person_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Person)
+    owner = Person(uid="orcid-0000-0000-0000-0009", display_name="Paul Martin",
+                   external=True,
+                   identifiers=[{"type": "orcid", "value": "0000-0000-0000-0009"}])
+    await person_dao.create(owner)
+
+    contributions = [{
+        "rank": 0, "roles": [CTB],
+        "person": {"uid": None, "displayName": "Paul Martin",
+                   "identifiers": [{"type": "orcid", "value": "0000-0000-0000-0009"}]},
+        "affiliations": [],
+    }]
+    await ChangeService().create_and_apply_change(
+        _contributions_change(document.uid, contributions))
+
+    contributor_uids = await _contributor_uids(document.uid)
+    assert contributor_uids == {owner.uid}
+
+
+@pytest.mark.asyncio
+async def test_clear_shared_identifiers_detaches_external_edge(
+        test_app,  # pylint: disable=unused-argument
+        persisted_person_a_pydantic_model: Person) -> None:
+    """
+    The cleanup detaches a shared AgentIdentifier from the external person while leaving the
+    node, the external person and the internal owner intact.
+    """
+    internal = persisted_person_a_pydantic_model
+    person_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Person)
+    shared = (await person_dao.get(internal.uid)).identifiers[0]
+    shared_id = {"type": shared.type.value, "value": shared.value}
+
+    external = Person(uid="hal-ext-shared", display_name="Shared Owner",
+                      external=True, identifiers=[])
+    await person_dao.create(external)
+    # simulate the bug: link the internal person's identifier onto the external person
+    await person_dao.add_person_identifiers(external.uid, [shared_id])
+
+    service = PeopleService()
+    rows = await service.find_external_internal_shared_identifiers()
+    assert any(r["external_uid"] == external.uid
+               and r["internal_uid"] == internal.uid
+               and r["id_value"] == shared.value for r in rows)
+
+    detached = await service.detach_external_shared_identifiers()
+    assert detached >= 1
+
+    external_keys = {(i.type.value, i.value)
+                     for i in (await person_dao.get(external.uid)).identifiers}
+    assert (shared.type.value, shared.value) not in external_keys
+    # the internal owner keeps the identifier
+    internal_keys = {(i.type.value, i.value)
+                     for i in (await person_dao.get(internal.uid)).identifiers}
+    assert (shared.type.value, shared.value) in internal_keys
+    # nothing left shared
+    assert await service.find_external_internal_shared_identifiers() == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A sovisuplus contribution-update message could attach an `AgentIdentifier` already owned by an internal person onto an external co-author, leaving one identifier node owned by two `Person` nodes (e.g. external *Lamy, Jérôme* ↔ internal *local-jelamy* sharing `idhals=jerome-lamy`, `idref`, `orcid`). sovisuplus then refuses the alignment ("already attributed to someone else").

Root cause: `ContributionUpdateService._resolve_person` skipped conflict detection in the uid-provided branch, so `MERGE` re-used the internal person's identifier nodes and added a second `HAS_IDENTIFIER` edge.

## Fix

- **Re-point** the contribution to whichever existing person *owns* an incoming identifier via `AgentIdentifier` — internal owners win over external, ties broken by name similarity.
  - Owner internal → freeze (no identifier/name writes).
  - Owner external → resolve + merge the other consistent identifiers (consolidates duplicate external co-authors).
- Conflict detection now applies to **both** branches (uid-provided and null-uid).
- `find_person_candidates_by_identifiers.cypher` returns a `via` flag (`agent`/`source`) so re-point is driven only by authoritative `AgentIdentifier` matches, never fuzzy source-id matches.

## One-shot cleanup

`people clear-shared-identifiers` (dry-run by default, `--apply` to act) reports every `AgentIdentifier` shared between an external and internal person and detaches the external edge — keeping the node, external person, and internal owner intact. Already run against the live graph: the Lamy collision is healed (0 shared identifiers remaining).

## Spec

`specs/fix-internal-external-author-identifier-collision/prompt.md`

## Tests

3 new tests (re-point to internal owner, consolidate onto external owner, cleanup detach). Full suite green; pylint 10.00/10.