### PR TITLE
fix: record HAL structId as a hal identifier on message affiliations

### DIFF
--- a/app/services/contributions/contribution_update_service.py
+++ b/app/services/contributions/contribution_update_service.py
@@ -11,6 +11,7 @@ from app.graph.neo4j.document_dao import DocumentDAO
 from app.graph.neo4j.person_dao import PersonDAO
 from app.models.document import Document
 from app.models.harvesting_sources import HarvestingSource
+from app.models.identifier_types import OrganizationIdentifierType
 from app.models.people import Person
 from app.models.source_organization_identifiers import SourceOrganizationIdentifier
 from app.models.source_organizations import SourceOrganization
@@ -311,7 +312,14 @@ class ContributionUpdateService:
             logger.warning("Affiliation without usable identifier skipped: %s", affiliation)
             return None
 
-        identifiers = [
+        identifiers = []
+        # The HAL structId is both the source key and a genuine identifier: record it as a
+        # ``hal`` identifier so the resolved authority is identified and converges (by identifier)
+        # on the harvested authority keyed on the same structId.
+        if affiliation.get("hal"):
+            identifiers.append(SourceOrganizationIdentifier(
+                type=OrganizationIdentifierType.HAL.value, value=str(affiliation["hal"])))
+        identifiers += [
             SourceOrganizationIdentifier(type=key, value=affiliation[key])
             for key in self._AFFILIATION_IDENTIFIER_KEYS
             if affiliation.get(key)

--- a/tests/test_services/test_contribution_update_service.py
+++ b/tests/test_services/test_contribution_update_service.py
@@ -62,6 +62,20 @@ async def _count_affiliation_statements(document_uid: str) -> int:
             return record["n"]
 
 
+async def _affiliation_identifiers(document_uid: str) -> set:
+    query = (
+        "MATCH (:Document {uid: $uid})-[:HAS_CONTRIBUTION]->(:Contribution)"
+        "-[:HAS_AFFILIATION_STATEMENT]->(:AuthorityOrganization)"
+        "-[:HAS_IDENTIFIER]->(i:AgentIdentifier) "
+        "RETURN collect(DISTINCT [i.type, i.value]) AS ids"
+    )
+    async with Neo4jConnexion().get_driver() as driver:
+        async with driver.session() as session:
+            result = await session.run(query, uid=document_uid)
+            record = await result.single()
+            return {(t, v) for t, v in record["ids"]}
+
+
 def test_factory_routes_contributions_to_processor() -> None:
     """The factory routes a path=contributions document change to the new processor."""
     change = _contributions_change("doc-1", [])
@@ -366,3 +380,32 @@ async def test_replay_emits_batch_mode(
 
     assert mocked_document_updated_signal.call_args is not None
     assert mocked_document_updated_signal.call_args.kwargs["mode"] == MessageMode.BATCH
+
+
+@pytest.mark.asyncio
+async def test_affiliation_hal_structid_becomes_identifier(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        persisted_person_a_pydantic_model: Person,
+        mocked_document_updated_signal) -> None:  # pylint: disable=unused-argument
+    """
+    An affiliation whose only identifier is a HAL structId resolves to an authority that
+    carries a `hal` identifier (so sovisuplus sees it as identified).
+    """
+    document = document_hal_article_a_persisted_model
+    internal = persisted_person_a_pydantic_model
+    contributions = [{
+        "rank": 0, "roles": [AUT],
+        "person": {"uid": internal.uid, "displayName": internal.display_name,
+                   "identifiers": []},
+        "affiliations": [
+            {"hal": "1210550", "nns": None, "ror": None, "isni": None,
+             "name": "University of Bologna - DIMEVET", "type": "institution",
+             "idref": None, "label": "University of Bologna - DIMEVET",
+             "acronym": None, "wikidata": None}
+        ],
+    }]
+    await ChangeService().create_and_apply_change(
+        _contributions_change(document.uid, contributions))
+
+    assert ("hal", "1210550") in await _affiliation_identifiers(document.uid)


### PR DESCRIPTION
## Problem

When a sovisuplus contribution-update message carries an affiliation whose only identifier is a HAL structId (e.g. *University of Bologna - DIMEVET*, `hal: "1210550"`, no idref/ror/…), the resolved `AuthorityOrganization` ends up with **no identifiers** and sovisuplus reports it as "not identified".

Root cause: in `ContributionUpdateService._build_source_organization`, the HAL structId was used **only** as the `SourceOrganization.source_identifier` (uid key), never added to `SourceOrganization.identifiers`. The identifier list was built solely from `idref/ror/isni/nns/wikidata`. The harvested path, by contrast, carries the structId both as the source key *and* as a `{"type": "hal", "value": "<structId>"}` identifier — so authority resolution (`_attach`, via `OrganizationIdentifierType.HAL = "hal"`) gives harvested authorities a `hal` identifier but contribution-derived ones none.

This also defeated the #391 "converge on the same authority as the harvested one" intent: convergence happens by **identifier** matching (`get_states_with_compatible_identifiers`), which needs the `hal` identifier present.

## Fix

`_build_source_organization` now records the HAL structId as a `hal` `SourceOrganizationIdentifier` when present (in addition to the existing keys). `source_identifier` is unchanged.

Effect: affiliations resolve to authorities that carry the `hal` identifier (so sovisuplus identifies them) and converge by `hal` id on the existing harvested authority.

## Tests

New test `test_affiliation_hal_structid_becomes_identifier` (affiliation with only a HAL structId → authority carries `hal` identifier). Full contribution-update suite, source-record contribution suites, and authority-org service suite pass; pylint 10.00/10.