### PR TITLE
feat(#402): report and record user-action errors

### DIFF
--- a/app/amqp/amqp_change_applied_event_message_factory.py
+++ b/app/amqp/amqp_change_applied_event_message_factory.py
@@ -1,0 +1,11 @@
+from app.amqp.amqp_change_event_message_factory import AMQPChangeEventMessageFactory
+
+
+class AMQPChangeAppliedEventMessageFactory(AMQPChangeEventMessageFactory):
+    """Factory for AMQP messages reporting a successfully applied change."""
+
+    def _build_routing_key(self) -> str:
+        return self.settings.amqp_graph_change_event_applied_routing_key
+
+    def _event_name(self) -> str:
+        return "applied"

--- a/app/amqp/amqp_change_event_message_factory.py
+++ b/app/amqp/amqp_change_event_message_factory.py
@@ -1,0 +1,24 @@
+from abc import abstractmethod
+from typing import Any
+
+from app.amqp.abstract_amqp_message_factory import AbstractAMQPMessageFactory
+
+
+class AMQPChangeEventMessageFactory(AbstractAMQPMessageFactory):
+    """
+    Base factory for AMQP messages reporting the outcome of a user-action change.
+
+    The payload is built purely from the pre-computed ``fields`` dict carried by the
+    change signals (see ``Change.to_event_fields``) — no database round-trip.
+    """
+
+    async def _build_payload(self) -> dict[str, Any]:
+        return {
+            "type": "change",
+            "event": self._event_name(),
+            "fields": self.content.get("fields"),
+        }
+
+    @abstractmethod
+    def _event_name(self) -> str:  # pragma: no cover
+        raise NotImplementedError()

--- a/app/amqp/amqp_change_failed_event_message_factory.py
+++ b/app/amqp/amqp_change_failed_event_message_factory.py
@@ -1,0 +1,11 @@
+from app.amqp.amqp_change_event_message_factory import AMQPChangeEventMessageFactory
+
+
+class AMQPChangeFailedEventMessageFactory(AMQPChangeEventMessageFactory):
+    """Factory for AMQP messages reporting a failed change."""
+
+    def _build_routing_key(self) -> str:
+        return self.settings.amqp_graph_change_event_failed_routing_key
+
+    def _event_name(self) -> str:
+        return "failed"

--- a/app/amqp/amqp_interface.py
+++ b/app/amqp/amqp_interface.py
@@ -474,6 +474,41 @@ class AMQPInterface:
                                 {"document_uid": document_uid},
                                 mode=mode)
 
+    async def dispatch_change_applied(self, _, **extra) -> None:
+        """
+        Dispatch a change applied event (user-action outcome, interactive only)
+        :param _: sender of message (unused)
+        :param extra: extra parameters carrying the change event fields
+        :return: None
+        """
+        event_message_subtype = AMQPMessagePublisher.EventMessageSubtype.CHANGE_APPLIED
+        await self._dispatch_change_event(event_message_subtype, extra["fields"])
+
+    async def dispatch_change_failed(self, _, **extra) -> None:
+        """
+        Dispatch a change failed event (user-action outcome, interactive only)
+        :param _: sender of message (unused)
+        :param extra: extra parameters carrying the change event fields
+        :return: None
+        """
+        event_message_subtype = AMQPMessagePublisher.EventMessageSubtype.CHANGE_FAILED
+        await self._dispatch_change_event(event_message_subtype, extra["fields"])
+
+    async def _dispatch_change_event(self, event_message_subtype, fields: dict):
+        logger.info(
+            f"Dispatching change event: {event_message_subtype}"
+            f" for change {fields.get('uid')}")
+        exchange = self.pika_exchanges.get(self.settings.amqp_graph_exchange_name, None)
+        if not exchange:
+            logger.error("Cannot dispatch {} event for change {}: "
+                         "AMQP exchange not declared", event_message_subtype, fields.get("uid"))
+            return
+        publisher = AMQPMessagePublisher(exchange)
+        await publisher.publish(AMQPMessagePublisher.MessageType.EVENT,
+                                event_message_subtype,
+                                {"fields": fields},
+                                mode=MessageMode.INTERACTIVE)
+
     async def dispatch_harvesting_state_event(self, _, **extra):
         """
         Dispatch a harvesting state event

--- a/app/amqp/amqp_message_publisher.py
+++ b/app/amqp/amqp_message_publisher.py
@@ -7,6 +7,10 @@ from loguru import logger
 
 from app.amqp.message_mode import MessageMode
 
+from app.amqp.amqp_change_applied_event_message_factory import \
+    AMQPChangeAppliedEventMessageFactory
+from app.amqp.amqp_change_failed_event_message_factory import \
+    AMQPChangeFailedEventMessageFactory
 from app.amqp.amqp_document_created_event_message_factory import \
     AMQPDocumentCreatedEventMessageFactory
 from app.amqp.amqp_document_deleted_event_message_factory import \
@@ -77,6 +81,8 @@ class AMQPMessagePublisher:
         DOCUMENT_CREATED = "Document created"
         DOCUMENT_DELETED = "Document deleted"
         DOCUMENT_UNCHANGED = "Document unchanged"
+        CHANGE_APPLIED = "Change applied"
+        CHANGE_FAILED = "Change failed"
         HARVESTING_STATE_EVENT = "Harvesting state event"
         HARVESTING_RESULT_EVENT = "Harvesting result event"
 
@@ -97,6 +103,8 @@ class AMQPMessagePublisher:
             EventMessageSubtype.DOCUMENT_UPDATED: AMQPDocumentUpdatedEventMessageFactory,
             EventMessageSubtype.DOCUMENT_DELETED: AMQPDocumentDeletedEventMessageFactory,
             EventMessageSubtype.DOCUMENT_UNCHANGED: AMQPDocumentUnchangedEventMessageFactory,
+            EventMessageSubtype.CHANGE_APPLIED: AMQPChangeAppliedEventMessageFactory,
+            EventMessageSubtype.CHANGE_FAILED: AMQPChangeFailedEventMessageFactory,
             EventMessageSubtype.HARVESTING_STATE_EVENT: AMQPHarvestingStateEventMessageFactory,
             EventMessageSubtype.HARVESTING_RESULT_EVENT: AMQPHarvestingResultEventMessageFactory,
         },

--- a/app/amqp/amqp_user_actions_message_processor.py
+++ b/app/amqp/amqp_user_actions_message_processor.py
@@ -1,14 +1,17 @@
 # file: app/amqp/amqp_user_actions_message_processor.py
 
+from datetime import datetime, timezone
+
 from loguru import logger
 from pydantic import ValidationError
 
 from app.amqp.amqp_message_processor import AMQPMessageProcessor
 from app.amqp.message_mode import MessageMode
-from app.models.change import Change
+from app.models.change import Change, ChangeStatus
 from app.models.identifier_types import PersonIdentifierType
 from app.services.changes.change_service import ChangeService
 from app.services.people.people_service import PeopleService
+from app.signals import change_failed
 
 
 class AMQPUserActionsMessageProcessor(AMQPMessageProcessor):
@@ -51,9 +54,35 @@ class AMQPUserActionsMessageProcessor(AMQPMessageProcessor):
         try:
             change = Change.model_validate(json_payload)
         except ValidationError as e:
+            # no valid Change can be built: the failure event is the only record
+            await change_failed.send_async(
+                self, fields=self._invalid_change_fields(json_payload, e))
             raise ValueError(f"Failed to build Change object: {e}") from e
         # exceptions are handled in the base class
         await self.change_service.create_and_apply_change(change)
+
+    @staticmethod
+    def _invalid_change_fields(json_payload: dict, error: ValidationError) -> dict:
+        """
+        Build change-failed event fields from a raw payload that failed validation,
+        so the originating application can still correlate the failure.
+        """
+        application = json_payload.get("application")
+        raw_id = json_payload.get("id")
+        return {
+            "uid": f"{application}:{raw_id}" if application and raw_id else None,
+            "id": raw_id,
+            "application": application,
+            "person_uid": json_payload.get("personUid"),
+            "target_type": json_payload.get("targetType"),
+            "target_uid": json_payload.get("targetUid"),
+            "path": json_payload.get("path"),
+            "action_type": json_payload.get("actionType"),
+            "status": ChangeStatus.FAILED.value,
+            "error_message": f"invalid message: {error}",
+            "warnings": [],
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
 
     async def _process_unregistered_change(self, json_payload: str):
         """

--- a/app/crisalid_ikg.py
+++ b/app/crisalid_ikg.py
@@ -30,7 +30,8 @@ from app.signals import person_created, person_identifiers_updated, source_recor
     document_unchanged, document_deleted, structure_unchanged, structure_deleted, \
     person_deleted, person_updated, publications_to_be_updated, source_journal_created, \
     source_journal_updated, harvesting_state_event_received, harvesting_result_event_received, \
-    document_created_from_sources, authority_organisation_state_updated
+    document_created_from_sources, authority_organisation_state_updated, \
+    change_applied, change_failed
 
 
 class CrisalidIKG(FastAPI):  # pylint: disable=too-many-instance-attributes
@@ -139,6 +140,8 @@ class CrisalidIKG(FastAPI):  # pylint: disable=too-many-instance-attributes
         document_created.connect(self.amqp_interface.dispatch_document_created)
         document_unchanged.connect(self.amqp_interface.dispatch_document_unchanged)
         document_deleted.connect(self.amqp_interface.dispatch_document_deleted)
+        change_applied.connect(self.amqp_interface.dispatch_change_applied)
+        change_failed.connect(self.amqp_interface.dispatch_change_failed)
 
     def _register_harvesting_events(self):
         harvesting_state_event_received.connect(self.amqp_interface.dispatch_harvesting_state_event)

--- a/app/graph/neo4j/change_dao.py
+++ b/app/graph/neo4j/change_dao.py
@@ -89,7 +89,8 @@ class ChangeDAO(Neo4jDAO):
             params=change.marshal_parameters(),
             timestamp=change.timestamp.isoformat(),
             status=change.status.value,
-            error_message=change.error_message
+            error_message=change.error_message,
+            warnings=change.marshal_warnings()
         )
 
     @staticmethod
@@ -99,7 +100,8 @@ class ChangeDAO(Neo4jDAO):
             query,
             uid=change.uid,
             status=change.status.value,
-            error_message=change.error_message
+            error_message=change.error_message,
+            warnings=change.marshal_warnings()
         )
 
     @classmethod

--- a/app/graph/neo4j/queries/create_document_change.cypher
+++ b/app/graph/neo4j/queries/create_document_change.cypher
@@ -7,7 +7,8 @@ c.path = $path,
 c.parameters = $params,
 c.timestamp = datetime($timestamp),
 c.status = $status,
-c.error_message = $error_message
+c.error_message = $error_message,
+c.warnings = $warnings
 
 WITH c
 MATCH (d:Document {uid: $document_uid})

--- a/app/graph/neo4j/queries/update_change_status.cypher
+++ b/app/graph/neo4j/queries/update_change_status.cypher
@@ -1,4 +1,5 @@
 MATCH (c:Change {uid: $uid})
 SET c.status = $status,
-c.error_message = $error_message
+c.error_message = $error_message,
+c.warnings = $warnings
 RETURN c

--- a/app/models/change.py
+++ b/app/models/change.py
@@ -1,9 +1,11 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Literal, Optional
 
 from pydantic import BaseModel, model_validator, Field, field_validator, AliasChoices
+
+from app.models.change_report import ChangeWarning
 
 
 class ChangeStatus(str, Enum):
@@ -45,6 +47,7 @@ class Change(BaseModel):
     timestamp: datetime
     status: ChangeStatus = ChangeStatus.CREATED
     error_message: Optional[str] = None  # if status == FAILED
+    warnings: list[ChangeWarning] = []  # per-item losses
 
     @model_validator(mode="before")
     @classmethod
@@ -70,8 +73,45 @@ class Change(BaseModel):
                 raise ValueError("Invalid JSON in parameters field") from e
         return v
 
+    @field_validator("warnings", mode="before")
+    @classmethod
+    def _unmarshal_warnings(cls, v):
+        if isinstance(v, str):
+            try:
+                return json.loads(v)
+            except json.JSONDecodeError as e:
+                raise ValueError("Invalid JSON in warnings field") from e
+        return v
+
     def marshal_parameters(self) -> str:
         """
         Convert parameters to a JSON string for storage.
         """
         return json.dumps(self.parameters, ensure_ascii=False)
+
+    def marshal_warnings(self) -> str:
+        """
+        Convert warnings to a JSON string for storage.
+        """
+        return json.dumps([warning.model_dump() for warning in self.warnings],
+                          ensure_ascii=False)
+
+    def to_event_fields(self) -> dict:
+        """
+        Build the JSON-safe ``fields`` payload of an outbound change event message.
+        """
+        return {
+            "uid": self.uid,
+            "id": self.id,
+            "application": self.application,
+            "person_uid": self.person_uid,
+            # false positive: pylint infers FieldInfo for the aliased field
+            "target_type": self.target_type.value,  # pylint: disable=no-member
+            "target_uid": self.target_uid,
+            "path": self.path,
+            "action_type": self.action_type,
+            "status": self.status.value,
+            "error_message": self.error_message,
+            "warnings": [warning.model_dump() for warning in self.warnings],
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }

--- a/app/models/change_report.py
+++ b/app/models/change_report.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel, Field
+
+
+class ChangeWarning(BaseModel):
+    """
+    A per-item problem encountered while applying a Change: the change was applied
+    but this particular element was skipped or degraded.
+    """
+
+    code: str
+    message: str
+    context: dict = Field(default_factory=dict)
+
+
+class ChangeApplicationReport(BaseModel):
+    """
+    Outcome report of a change application, accumulated by change processors.
+    An empty warnings list means a clean success.
+    """
+
+    warnings: list[ChangeWarning] = []
+
+    def add_warning(self, code: str, message: str, **context) -> None:
+        """
+        Record a per-item warning.
+        :param code: machine-readable warning code (e.g. "UNRESOLVABLE_PERSON")
+        :param message: human-readable description
+        :param context: JSON-serializable details (names, identifiers, error strings)
+        """
+        self.warnings.append(ChangeWarning(code=code, message=message, context=context))

--- a/app/models/people.py
+++ b/app/models/people.py
@@ -63,13 +63,6 @@ class Person(Agent[PersonIdentifierType]):
                 )
                 continue
 
-            if not PersonIdentifierType.validate_identifier(identifier.type, identifier.value):
-                logger.warning(
-                    "Invalid identifier with type "
-                    f"{str(identifier.type)} and value {identifier.value}"
-                )
-                continue
-
             valid_identifiers.append(identifier)
 
         return cls._deduplicate_identifiers(valid_identifiers)

--- a/app/services/changes/change_service.py
+++ b/app/services/changes/change_service.py
@@ -12,7 +12,7 @@ from app.models.change import Change, TargetType, ChangeStatus
 from app.models.document import Document
 from app.services.changes.change_processor_factory import ChangeProcessorFactory
 from app.amqp.message_mode import MessageMode
-from app.signals import document_updated
+from app.signals import document_updated, change_applied, change_failed
 
 
 class ChangeService:
@@ -37,12 +37,23 @@ class ChangeService:
                 return
             if existing.status == ChangeStatus.FAILED:
                 logger.info(f"Change {change.uid} had failed. Retrying.")
-                return
-            logger.info(f"Change {change.uid} found bu not applied. Applying.")
+                existing.error_message = None
+                existing.warnings = []
+            else:
+                logger.info(f"Change {change.uid} found but not applied. Applying.")
             await self.apply_change(existing, mode=mode)
         else:
             logger.info(f"Change {change.uid} not found. Creating and applying.")
-            await self.create_change(change)
+            try:
+                await self.create_change(change)
+            except (DatabaseError, ValueError) as e:
+                # the Change node is not persisted (e.g. missing target document):
+                # the failure event and the logs are the only record
+                change.status = ChangeStatus.FAILED
+                change.error_message = str(e)
+                logger.error(f"Failed to create change {change.uid}: {e}")
+                await self._signal_change_failed(change, mode)
+                raise
             await self.apply_change(change, mode=mode)
 
     async def create_change(self, change: Change) -> Change:
@@ -70,9 +81,13 @@ class ChangeService:
         """
         try:
             processor = ChangeProcessorFactory.get_processor(change)
-            await processor.apply()
+            report = await processor.apply()
             change.status = ChangeStatus.APPLIED
+            change.error_message = None
+            change.warnings = report.warnings if report else []
             await self._update_change_status(change)
+            if mode == MessageMode.INTERACTIVE:
+                await change_applied.send_async(self, fields=change.to_event_fields())
             # for MERGE changes, the document_updated signal is sent by the processor
             if change.target_type == TargetType.DOCUMENT and change.action_type not in ("MERGE"):
                 await document_updated.send_async(self, document_uid=change.target_uid,
@@ -82,6 +97,7 @@ class ChangeService:
             change.error_message = str(e)
             await self._update_change_status(change)
             logger.error(f"Failed to apply change {change.uid}: {e}")
+            await self._signal_change_failed(change, mode)
             raise e
 
     async def apply_changes_to_node(
@@ -114,6 +130,13 @@ class ChangeService:
                 await self.apply_change(change, mode=mode)
             except (DatabaseError, ValueError) as e:
                 logger.error(f"Failed to apply change {change.uid} to {target_uid}: {e}")
+
+    async def _signal_change_failed(self, change: Change, mode: MessageMode) -> None:
+        """
+        Emit the change-failed event; batch replays stay silent toward clients.
+        """
+        if mode == MessageMode.INTERACTIVE:
+            await change_failed.send_async(self, fields=change.to_event_fields())
 
     async def _update_change_status(self, change: Change) -> None:
         """

--- a/app/services/changes/processors/abstract_change_processor.py
+++ b/app/services/changes/processors/abstract_change_processor.py
@@ -1,6 +1,12 @@
 from abc import ABC, abstractmethod
+from typing import cast
 
+from app.config import get_app_settings
+from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
+from app.graph.neo4j.document_dao import DocumentDAO
 from app.models.change import Change
+from app.models.change_report import ChangeApplicationReport
+from app.models.document import Document
 
 
 class AbstractChangeProcessor(ABC):
@@ -13,8 +19,18 @@ class AbstractChangeProcessor(ABC):
         self.change = change
 
     @abstractmethod
-    async def apply(self) -> None:
+    async def apply(self) -> ChangeApplicationReport:
         """
-        Apply the change to the graph.
+        Apply the change to the graph and return an application report
+        (an empty report means a clean success).
         Should raise ValueError or DatabaseError on failure.
         """
+
+    def _get_document_dao(self) -> DocumentDAO:
+        factory = self._get_dao_factory()
+        return cast(DocumentDAO, factory.get_dao(Document))
+
+    @staticmethod
+    def _get_dao_factory():
+        settings = get_app_settings()
+        return AbstractDAOFactory().get_dao_factory(settings.graph_db)

--- a/app/services/changes/processors/document_abstract_change_processor.py
+++ b/app/services/changes/processors/document_abstract_change_processor.py
@@ -1,9 +1,4 @@
-from typing import cast
-
-from app.config import get_app_settings
-from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
-from app.graph.neo4j.document_dao import DocumentDAO
-from app.models.document import Document
+from app.models.change_report import ChangeApplicationReport
 from app.models.text_literal import TextLiteral
 from app.services.changes.processors.abstract_change_processor import AbstractChangeProcessor
 
@@ -13,7 +8,7 @@ class DocumentAbstractChangeProcessor(AbstractChangeProcessor):
     Processor for changes related to the titles of a Document.
     """
 
-    async def apply(self) -> None:
+    async def apply(self) -> ChangeApplicationReport:
 
         document_uid = self.change.target_uid
         abstract_value = self.change.parameters.get("value")
@@ -32,11 +27,4 @@ class DocumentAbstractChangeProcessor(AbstractChangeProcessor):
 
         except ValueError as exc:
             raise ValueError(f"Invalid new document abstract: {abstract_value}") from exc
-
-    def _get_document_dao(self) -> DocumentDAO:
-        factory = self._get_dao_factory()
-        return cast(DocumentDAO, factory.get_dao(Document))
-
-    def _get_dao_factory(self):
-        settings = get_app_settings()
-        return AbstractDAOFactory().get_dao_factory(settings.graph_db)
+        return ChangeApplicationReport()

--- a/app/services/changes/processors/document_contributions_change_processor.py
+++ b/app/services/changes/processors/document_contributions_change_processor.py
@@ -1,3 +1,4 @@
+from app.models.change_report import ChangeApplicationReport
 from app.services.changes.processors.abstract_change_processor import AbstractChangeProcessor
 from app.services.contributions.contribution_update_service import ContributionUpdateService
 
@@ -11,7 +12,7 @@ class DocumentContributionsChangeProcessor(AbstractChangeProcessor):
     that list (replace semantics).
     """
 
-    async def apply(self) -> None:
+    async def apply(self) -> ChangeApplicationReport:
         document_uid = self.change.target_uid
         if not isinstance(document_uid, str):
             raise ValueError(f"Invalid 'targetUid' in change: {self.change.target_uid}")
@@ -22,7 +23,7 @@ class DocumentContributionsChangeProcessor(AbstractChangeProcessor):
                 f"Invalid 'contributions' in parameters of change {self.change.uid}: "
                 f"expected a list, got {type(contributions).__name__}")
 
-        await ContributionUpdateService().reconcile(
+        return await ContributionUpdateService().reconcile(
             document_uid=document_uid,
             contributions=contributions,
         )

--- a/app/services/changes/processors/document_merge_change_processor.py
+++ b/app/services/changes/processors/document_merge_change_processor.py
@@ -1,6 +1,7 @@
 from typing import Set, List, Optional
 
 from app.amqp.message_mode import MessageMode
+from app.models.change_report import ChangeApplicationReport
 from app.services.changes.processors.abstract_change_processor import AbstractChangeProcessor
 from app.services.documents.document_service import DocumentService
 
@@ -10,7 +11,7 @@ class DocumentMergeChangeProcessor(AbstractChangeProcessor):
     Processor for user-initiated document merge actions.
     """
 
-    async def apply(self) -> None:
+    async def apply(self) -> ChangeApplicationReport:
 
         params = self.change.parameters or {}
         merged_list: Optional[List[str]] = None
@@ -41,3 +42,4 @@ class DocumentMergeChangeProcessor(AbstractChangeProcessor):
 
         service = DocumentService()
         await service.merge_documents(all_uids, mode=MessageMode.INTERACTIVE)
+        return ChangeApplicationReport()

--- a/app/services/changes/processors/document_subjects_change_processor.py
+++ b/app/services/changes/processors/document_subjects_change_processor.py
@@ -1,9 +1,4 @@
-from typing import cast
-
-from app.config import get_app_settings
-from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
-from app.graph.neo4j.document_dao import DocumentDAO
-from app.models.document import Document
+from app.models.change_report import ChangeApplicationReport
 from app.services.changes.processors.abstract_change_processor import AbstractChangeProcessor
 
 
@@ -12,7 +7,7 @@ class DocumentSubjectsChangeProcessor(AbstractChangeProcessor):
     Processor for changes related to the subjects of a Document.
     """
 
-    async def apply(self) -> None:
+    async def apply(self) -> ChangeApplicationReport:
 
         document_uid = self.change.target_uid
         if not isinstance(document_uid, str):
@@ -48,11 +43,4 @@ class DocumentSubjectsChangeProcessor(AbstractChangeProcessor):
                                                        subject_uri=subject_uri,
                                                        subject_pref_labels=subject_pref_labels,
                                                        subject_alt_labels=subject_alt_labels)
-
-    def _get_document_dao(self) -> DocumentDAO:
-        factory = self._get_dao_factory()
-        return cast(DocumentDAO, factory.get_dao(Document))
-
-    def _get_dao_factory(self):
-        settings = get_app_settings()
-        return AbstractDAOFactory().get_dao_factory(settings.graph_db)
+        return ChangeApplicationReport()

--- a/app/services/changes/processors/document_title_change_processor.py
+++ b/app/services/changes/processors/document_title_change_processor.py
@@ -1,9 +1,4 @@
-from typing import cast
-
-from app.config import get_app_settings
-from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
-from app.graph.neo4j.document_dao import DocumentDAO
-from app.models.document import Document
+from app.models.change_report import ChangeApplicationReport
 from app.services.changes.processors.abstract_change_processor import AbstractChangeProcessor
 
 
@@ -12,7 +7,7 @@ class DocumentTitleChangeProcessor(AbstractChangeProcessor):
     Processor for changes related to the titles of a Document.
     """
 
-    async def apply(self) -> None:
+    async def apply(self) -> ChangeApplicationReport:
 
         document_uid = self.change.target_uid
         title = self.change.parameters.get("value")
@@ -32,11 +27,4 @@ class DocumentTitleChangeProcessor(AbstractChangeProcessor):
 
         except ValueError as exc:
             raise ValueError(f"Invalid new document title: {title}") from exc
-
-    def _get_document_dao(self) -> DocumentDAO:
-        factory = self._get_dao_factory()
-        return cast(DocumentDAO, factory.get_dao(Document))
-
-    def _get_dao_factory(self):
-        settings = get_app_settings()
-        return AbstractDAOFactory().get_dao_factory(settings.graph_db)
+        return ChangeApplicationReport()

--- a/app/services/changes/processors/document_type_change_processor.py
+++ b/app/services/changes/processors/document_type_change_processor.py
@@ -1,9 +1,4 @@
-from typing import cast
-
-from app.config import get_app_settings
-from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
-from app.graph.neo4j.document_dao import DocumentDAO
-from app.models.document import Document
+from app.models.change_report import ChangeApplicationReport
 from app.services.changes.processors.abstract_change_processor import AbstractChangeProcessor
 
 
@@ -12,7 +7,7 @@ class DocumentTypeChangeProcessor(AbstractChangeProcessor):
     Processor for changes related to the type of a Document.
     """
 
-    async def apply(self) -> None:
+    async def apply(self) -> ChangeApplicationReport:
 
         document_uid = self.change.target_uid
         new_type = self.change.parameters.get("value")
@@ -23,11 +18,4 @@ class DocumentTypeChangeProcessor(AbstractChangeProcessor):
                                                        new_type=new_type)
         except ValueError as exc:
             raise ValueError(f"Invalid new document type: {new_type}") from exc
-
-    def _get_document_dao(self) -> DocumentDAO:
-        factory = self._get_dao_factory()
-        return cast(DocumentDAO, factory.get_dao(Document))
-
-    def _get_dao_factory(self):
-        settings = get_app_settings()
-        return AbstractDAOFactory().get_dao_factory(settings.graph_db)
+        return ChangeApplicationReport()

--- a/app/services/contributions/contribution_update_service.py
+++ b/app/services/contributions/contribution_update_service.py
@@ -140,7 +140,8 @@ class ContributionUpdateService:
             owner_uid, owner_external = owner
             await self._apply_identifier_policy(
                 owner_uid, owner_external, incoming_identifiers,
-                self._agent_inconsistent_keys(candidates, owner_uid), report, display_name)
+                self._agent_inconsistent_keys(candidates, owner_uid),
+                report=report, display_name=display_name)
             return owner_uid
 
         if uid:
@@ -148,7 +149,7 @@ class ContributionUpdateService:
             if existing is not None:
                 await self._apply_identifier_policy(
                     existing.uid, bool(existing.external), incoming_identifiers, set(),
-                    report, display_name)
+                    report=report, display_name=display_name)
                 return existing.uid
             # uid provided but not found: fall back to matching/creation
             logger.info("Person uid {} not found, falling back to identifier matching", uid)
@@ -185,7 +186,8 @@ class ContributionUpdateService:
 
         await self._apply_identifier_policy(
             selected, bool(persons[selected]["external"]), incoming_identifiers,
-            self._inconsistent_identifier_keys(id_to_persons, selected), report, display_name)
+            self._inconsistent_identifier_keys(id_to_persons, selected),
+            report=report, display_name=display_name)
         return selected
 
     @classmethod
@@ -243,6 +245,7 @@ class ContributionUpdateService:
             external: bool,
             incoming_identifiers: list[dict],
             inconsistent_keys: set,
+            *,
             report: ChangeApplicationReport,
             display_name: Optional[str],
     ) -> None:

--- a/app/services/contributions/contribution_update_service.py
+++ b/app/services/contributions/contribution_update_service.py
@@ -12,7 +12,7 @@ from app.graph.neo4j.person_dao import PersonDAO
 from app.models.change_report import ChangeApplicationReport
 from app.models.document import Document
 from app.models.harvesting_sources import HarvestingSource
-from app.models.identifier_types import OrganizationIdentifierType
+from app.models.identifier_types import OrganizationIdentifierType, PersonIdentifierType
 from app.models.people import Person
 from app.models.source_organization_identifiers import SourceOrganizationIdentifier
 from app.models.source_organizations import SourceOrganization
@@ -140,14 +140,15 @@ class ContributionUpdateService:
             owner_uid, owner_external = owner
             await self._apply_identifier_policy(
                 owner_uid, owner_external, incoming_identifiers,
-                self._agent_inconsistent_keys(candidates, owner_uid))
+                self._agent_inconsistent_keys(candidates, owner_uid), report, display_name)
             return owner_uid
 
         if uid:
             existing = await self._person_dao().get(uid)
             if existing is not None:
                 await self._apply_identifier_policy(
-                    existing.uid, bool(existing.external), incoming_identifiers, set())
+                    existing.uid, bool(existing.external), incoming_identifiers, set(),
+                    report, display_name)
                 return existing.uid
             # uid provided but not found: fall back to matching/creation
             logger.info("Person uid {} not found, falling back to identifier matching", uid)
@@ -184,7 +185,7 @@ class ContributionUpdateService:
 
         await self._apply_identifier_policy(
             selected, bool(persons[selected]["external"]), incoming_identifiers,
-            self._inconsistent_identifier_keys(id_to_persons, selected))
+            self._inconsistent_identifier_keys(id_to_persons, selected), report, display_name)
         return selected
 
     @classmethod
@@ -236,16 +237,19 @@ class ContributionUpdateService:
         """
         return {key for key, owners in id_to_persons.items() if owners - {selected}}
 
-    async def _apply_identifier_policy(
+    async def _apply_identifier_policy(  # pylint: disable=too-many-arguments
             self,
             person_uid: str,
             external: bool,
             incoming_identifiers: list[dict],
             inconsistent_keys: set,
+            report: ChangeApplicationReport,
+            display_name: Optional[str],
     ) -> None:
         """
         Internal people: identifiers are frozen (incoming identifiers ignored).
-        External people: add the consistent incoming identifiers (MERGE, names untouched).
+        External people: add the consistent and valid incoming identifiers
+        (MERGE, names untouched).
         """
         if not external:
             return
@@ -253,7 +257,36 @@ class ContributionUpdateService:
             identifier for identifier in incoming_identifiers
             if (identifier["type"], identifier["value"]) not in inconsistent_keys
         ]
+        consistent = self._validate_identifiers(consistent, report, display_name)
         await self._person_dao().add_person_identifiers(person_uid, consistent)
+
+    @staticmethod
+    def _validate_identifiers(
+            identifiers: list[dict], report: ChangeApplicationReport,
+            display_name: Optional[str]
+    ) -> list[dict]:
+        """
+        Keep only identifiers whose type is known and whose value matches the type-specific
+        pattern; each dropped identifier is reported — the Person model validators would
+        otherwise discard it silently and the DAO would persist it unchecked.
+        """
+        valid = []
+        for identifier in identifiers:
+            identifier_type = PersonIdentifierType.from_str(identifier["type"])
+            value = str(identifier["value"])
+            if identifier_type is None or not PersonIdentifierType.validate_identifier(
+                    identifier_type, value):
+                logger.warning("Invalid person identifier ignored: {}", identifier)
+                report.add_warning(
+                    "INVALID_IDENTIFIER",
+                    "Invalid person identifier ignored",
+                    type=identifier["type"],
+                    value=identifier["value"],
+                    display_name=display_name,
+                )
+                continue
+            valid.append({"type": identifier["type"], "value": value})
+        return valid
 
     @staticmethod
     def _select_by_name_similarity(
@@ -274,6 +307,8 @@ class ContributionUpdateService:
             self, incoming_identifiers: list[dict], display_name: Optional[str],
             report: ChangeApplicationReport
     ) -> Optional[str]:
+        incoming_identifiers = self._validate_identifiers(
+            incoming_identifiers, report, display_name)
         if not display_name:
             logger.warning("Cannot create external person without a display name")
             report.add_warning(

--- a/app/services/contributions/contribution_update_service.py
+++ b/app/services/contributions/contribution_update_service.py
@@ -9,6 +9,7 @@ from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
 from app.graph.generic.dao_factory import DAOFactory
 from app.graph.neo4j.document_dao import DocumentDAO
 from app.graph.neo4j.person_dao import PersonDAO
+from app.models.change_report import ChangeApplicationReport
 from app.models.document import Document
 from app.models.harvesting_sources import HarvestingSource
 from app.models.identifier_types import OrganizationIdentifierType
@@ -49,20 +50,32 @@ class ContributionUpdateService:
     def __init__(self) -> None:
         self.authority_organization_service = AuthorityOrganizationService()
 
-    async def reconcile(self, document_uid: str, contributions: list[dict]) -> None:
+    async def reconcile(self, document_uid: str,
+                        contributions: list[dict]) -> ChangeApplicationReport:
         """
         Reconcile the document's contributions to exactly the submitted list.
 
         :param document_uid: target document uid
         :param contributions: full ordered contribution list from the message
+        :return: application report with one warning per skipped or degraded item
         """
+        report = ChangeApplicationReport()
         document_dao = self._document_dao()
         contribution_ids: list[str] = []
         for contribution in contributions:
             person = contribution.get("person") or {}
-            person_uid = await self._resolve_person(person)
+            warnings_before = len(report.warnings)
+            person_uid = await self._resolve_person(person, report)
             if person_uid is None:
                 logger.warning("Skipping contribution with unresolvable person: {}", person)
+                # a more specific warning may already have been recorded during resolution
+                if len(report.warnings) == warnings_before:
+                    report.add_warning(
+                        "UNRESOLVABLE_PERSON",
+                        "Skipping contribution with unresolvable person",
+                        display_name=person.get("displayName") or person.get("display_name"),
+                        identifiers=self._incoming_identifiers(person),
+                    )
                 continue
             roles = contribution.get("roles") or []
             rank = contribution.get("rank")
@@ -73,22 +86,39 @@ class ContributionUpdateService:
                 rank=rank,
             )
             if contribution_id is None:
+                report.add_warning(
+                    "CONTRIBUTION_NOT_CREATED",
+                    "Contribution could not be created",
+                    person_uid=person_uid,
+                )
                 continue
-            targets = await self._resolve_affiliations(contribution.get("affiliations") or [])
+            targets = await self._resolve_affiliations(
+                contribution.get("affiliations") or [], report)
             await document_dao.update_contribution_affiliation_statements(
                 contribution_id=contribution_id,
                 targets=targets,
             )
             contribution_ids.append(contribution_id)
+        # Safety guard: a non-empty submitted list that resolved to nothing must not wipe
+        # every contributor from the document — abort and keep the previous state.
+        if contributions and not contribution_ids:
+            details = "; ".join(
+                f"{warning.code}: {warning.message}" for warning in report.warnings)
+            raise ValueError(
+                f"None of the {len(contributions)} submitted contributions could be applied "
+                f"to document {document_uid}; aborting to avoid removing all contributors"
+                f"{f' ({details})' if details else ''}")
         # Remove contributors absent from the submitted list
         await document_dao.delete_contributions_not_in(
             document_uid=document_uid,
             contribution_ids=contribution_ids,
         )
+        return report
 
     # ------------------------------------------------------------------ persons
 
-    async def _resolve_person(self, person: dict) -> Optional[str]:
+    async def _resolve_person(
+            self, person: dict, report: ChangeApplicationReport) -> Optional[str]:
         """
         Resolve the contribution's person to a graph Person uid, creating a new external
         person when necessary, and applying the internal/external identifier policy.
@@ -123,11 +153,11 @@ class ContributionUpdateService:
             logger.info("Person uid {} not found, falling back to identifier matching", uid)
 
         return await self._match_or_create_person(
-            candidates, incoming_identifiers, display_name)
+            candidates, incoming_identifiers, display_name, report)
 
     async def _match_or_create_person(
             self, candidates: list[dict], incoming_identifiers: list[dict],
-            display_name: Optional[str]
+            display_name: Optional[str], report: ChangeApplicationReport
     ) -> Optional[str]:
         """
         Match the person against source-identifier candidates (AgentIdentifier owners are
@@ -144,7 +174,8 @@ class ContributionUpdateService:
 
         distinct = list(persons.keys())
         if not distinct:
-            return await self._create_external_person(incoming_identifiers, display_name)
+            return await self._create_external_person(
+                incoming_identifiers, display_name, report)
 
         if len(distinct) == 1:
             selected = distinct[0]
@@ -240,10 +271,16 @@ class ContributionUpdateService:
         return best_uid
 
     async def _create_external_person(
-            self, incoming_identifiers: list[dict], display_name: Optional[str]
+            self, incoming_identifiers: list[dict], display_name: Optional[str],
+            report: ChangeApplicationReport
     ) -> Optional[str]:
         if not display_name:
             logger.warning("Cannot create external person without a display name")
+            report.add_warning(
+                "MISSING_DISPLAY_NAME",
+                "Cannot create external person without a display name",
+                identifiers=incoming_identifiers,
+            )
             return None
         person = Person(
             uid=None,
@@ -256,6 +293,12 @@ class ContributionUpdateService:
             return person_uid
         except (ConflictError, ValueError) as error:
             logger.error("Could not create external person {}: {}", display_name, error)
+            report.add_warning(
+                "EXTERNAL_PERSON_CREATION_FAILED",
+                "Could not create external person",
+                display_name=display_name,
+                error=str(error),
+            )
             return None
 
     @staticmethod
@@ -269,13 +312,15 @@ class ContributionUpdateService:
 
     # ------------------------------------------------------------- affiliations
 
-    async def _resolve_affiliations(self, affiliations: list[dict]) -> list[str]:
+    async def _resolve_affiliations(
+            self, affiliations: list[dict], report: ChangeApplicationReport) -> list[str]:
         """
         Resolve message affiliations to elected authority-organization target uids, reusing
         the existing in-memory authority resolution (no SourceOrganization node persisted).
         """
         source_organisations = [
-            org for org in (self._build_source_organization(aff) for aff in affiliations)
+            org for org in (self._build_source_organization(aff, report)
+                            for aff in affiliations)
             if org is not None
         ]
         if not source_organisations:
@@ -294,13 +339,21 @@ class ContributionUpdateService:
             except ConflictError as error:
                 logger.error(
                     "Conflict error while resolving affiliation {}: {}", organisation.uid, error)
+                report.add_warning(
+                    "AFFILIATION_CONFLICT",
+                    "Conflict error while resolving affiliation",
+                    source_organization_uid=organisation.uid,
+                    error=str(error),
+                )
 
         # pylint: disable=protected-access
         return SourceContributorMappingService\
             ._elect_authority_organizations_for_affiliation_statements(
                 root_objects, source_organisations)
 
-    def _build_source_organization(self, affiliation: dict) -> Optional[SourceOrganization]:
+    def _build_source_organization(
+            self, affiliation: dict,
+            report: ChangeApplicationReport) -> Optional[SourceOrganization]:
         source_identifier = affiliation.get("hal")
         if not source_identifier:
             # affiliations are normally HAL-sourced; fall back to any other identifier
@@ -310,6 +363,11 @@ class ContributionUpdateService:
                     break
         if not source_identifier:
             logger.warning("Affiliation without usable identifier skipped: {}", affiliation)
+            report.add_warning(
+                "AFFILIATION_WITHOUT_IDENTIFIER",
+                "Affiliation without usable identifier skipped",
+                affiliation=affiliation,
+            )
             return None
 
         identifiers = []

--- a/app/services/identifiers/identifier_service.py
+++ b/app/services/identifiers/identifier_service.py
@@ -33,9 +33,12 @@ class AgentIdentifierService:
                         f"{cls.IDENTIFIER_SEPARATOR}"
                         f"{selected_identifier.value}")
 
+        present = [f"{identifier.type.value}={identifier.value}"
+                   for identifier in entity.identifiers]
         raise ValueError(
-            f"No identifier from order {identifier_order} "
-            f"found in data : {entity.model_dump()}.")
+            f"Cannot compute uid for {entity.__class__.__name__}: no identifier of type "
+            f"{[identifier_type.value for identifier_type in identifier_order]} present "
+            f"(identifiers: {present or 'none'}).")
 
     @classmethod
     def compute_possible_uids_for(cls, entity: BaseModel) -> List[str]:

--- a/app/settings/app_settings.py
+++ b/app/settings/app_settings.py
@@ -164,7 +164,8 @@ class AppSettings(BaseSettings):
     person_identifier_order: list[PersonIdentifierType] = \
         [PersonIdentifierType.LOCAL,
          PersonIdentifierType.ORCID,
-         PersonIdentifierType.IDREF]
+         PersonIdentifierType.IDREF,
+         PersonIdentifierType.IDHALS]
 
     research_unit_identifier_order: list[OrganizationIdentifierType] = \
         [OrganizationIdentifierType.LOCAL,

--- a/app/settings/app_settings.py
+++ b/app/settings/app_settings.py
@@ -103,6 +103,8 @@ class AppSettings(BaseSettings):
     amqp_graph_document_event_updated_routing_key: str = "event.documents.document.updated"
     amqp_graph_document_event_deleted_routing_key: str = "event.documents.document.deleted"
     amqp_graph_document_event_unchanged_routing_key: str = "event.documents.document.unchanged"
+    amqp_graph_change_event_applied_routing_key: str = "event.changes.change.applied"
+    amqp_graph_change_event_failed_routing_key: str = "event.changes.change.failed"
     amqp_directory_structure_event_routing_key: str = "event.structures.structure.*.batch"
     amqp_harvester_publication_retrieval_routing_key: str = "task.entity.references.retrieval"
 

--- a/app/signals.py
+++ b/app/signals.py
@@ -16,6 +16,9 @@ structure_deleted = signal('structure-deleted')
 source_record_created = signal('source-record-created')
 source_record_updated = signal('source-record-updated')
 
+change_applied = signal('change-applied')
+change_failed = signal('change-failed')
+
 document_created_from_sources = signal('document-created-from-sources')
 document_sources_changed = signal('document-sources-changed')
 document_updated = signal('document-updated')

--- a/specs/improve-error-reporting-for-user-actions#402/prompt.md
+++ b/specs/improve-error-reporting-for-user-actions#402/prompt.md
@@ -1,0 +1,251 @@
+# Improve error reporting and error recording for user actions
+
+Issue: https://github.com/CRISalid-esr/crisalid-ikg/issues/402
+
+## Context
+
+When a user action arrives on the user-actions queue, `AMQPUserActionsMessageProcessor`
+builds a `Change` and hands it to `ChangeService.create_and_apply_change`, which persists the
+change, applies it through a change processor, and — on success — emits `document_updated`.
+The resulting outbound `event.documents.document.updated.interactive` message is what lets
+sovisuplus (where the action originated and where the edited data is frozen in the meantime)
+refresh its view and notify the user.
+
+Today the feedback loop only works for the happy path. Errors fall into two buckets, and
+neither reaches the user:
+
+### 1. Hard failures — change not applied, no outbound message at all
+
+`ChangeService.apply_change` catches `DatabaseError` / `ValueError`, sets
+`Change.status = FAILED`, stores `error_message` on the `Change` node, logs, and re-raises.
+The exception propagates to `AMQPMessageProcessor.wait_for_message`, the inbound message is
+nacked, and **nothing is published back**. Sovisuplus never learns the action failed; the
+frozen data stays frozen until some timeout or manual refresh.
+
+Additional hard-failure paths that never even reach a `Change` node:
+
+- `Change.model_validate` fails in `_process_registered_change` → `ValueError`, logged only;
+- `ChangeService.create_change` raises `ValueError` when the target document does not exist —
+  the change is not persisted, so there is not even a FAILED node recording the attempt.
+
+### 2. Partial failures — change "applied", losses silently swallowed
+
+During a full-state contribution update (`ContributionUpdateService.reconcile`, issue #391),
+several per-item problems are logged and skipped without affecting the change status:
+
+- `logger.warning("Skipping contribution with unresolvable person: {}", person)` —
+  the contribution is dropped from the reconciled list
+  (`app/services/contributions/contribution_update_service.py:65`);
+- `logger.error("Could not create external person {}: {}", display_name, error)` —
+  `ConflictError` / `ValueError` on external-person creation; contribution dropped
+  (`contribution_update_service.py:258`);
+- `logger.warning("Cannot create external person without a display name")` — contribution
+  dropped (`contribution_update_service.py:246`);
+- `logger.error("Conflict error while resolving affiliation {}: {}", ...)` — affiliation
+  silently missing from the contribution (`contribution_update_service.py:296`);
+- `logger.warning("Affiliation without usable identifier skipped: {}", affiliation)` —
+  affiliation silently dropped (`contribution_update_service.py:312`).
+
+Because `reconcile` has **replace semantics**, a skipped contribution is not merely "not
+added" — it is **removed** from the document if it existed before
+(`delete_contributions_not_in`). The change is then marked `APPLIED`, `document_updated`
+fires, and sovisuplus refreshes a document that silently lost an author the user just typed
+in. This is the worst case: the user gets positive feedback ("saved") for a partially
+destructive outcome.
+
+## Goal
+
+1. **Record** — every error or per-item warning produced while applying a user action must be
+   persisted on the `Change` node, not just logged.
+2. **Report** — the outcome (success / partial success / failure), with its errors and
+   warnings, must be emitted as a RabbitMQ message that sovisuplus can consume to unfreeze
+   the UI and notify the user.
+3. **Correlate** — the outbound message must let sovisuplus identify which action and which
+   user it concerns: the change uid (`application:id` — sovisuplus minted the `id`, so it can
+   correlate directly), the acting user (`person_uid`), and the target (`target_uid`).
+
+**Scope: registered document changes only.** The unregistered actions
+(`FETCH`, person-`ADD` in `_process_unregistered_change`) have no `Change` node; their error
+reporting is tracked separately.
+
+## Design
+
+### A. Two dedicated outbound change events
+
+Two new outbound event messages, `change.applied` and `change.failed`, report the outcome of
+a user action. The existing document-updated message stays exactly as it is: it remains the
+generic "data changed, resync" signal (it is emitted from many contexts — batch recompute,
+merges, CLI — and on hard failure it is not emitted at all, so it cannot carry outcome
+reports). The new change events are the "your action was processed, here is the outcome"
+signal. On success sovisuplus receives both; on failure only `change.failed`.
+
+**Change events are emitted only in interactive mode** — i.e. when the change is applied
+directly from the sovisuplus user-action message (`MessageMode.INTERACTIVE`). Batch replays
+stay silent toward clients (see section G).
+
+### B. Message contract
+
+Routing keys (graph exchange; the publisher appends the mode suffix, which is always
+`interactive` here):
+
+```
+event.changes.change.applied.interactive
+event.changes.change.failed.interactive
+```
+
+New settings: `amqp_graph_change_event_applied_routing_key` /
+`amqp_graph_change_event_failed_routing_key` (pattern of the existing
+`amqp_graph_document_event_*_routing_key` settings).
+
+Payload:
+
+```jsonc
+{
+  "type": "change",
+  "event": "applied | failed",
+  "fields": {
+    "uid": "sovisuplus:0000-...-0001",     // Change uid = application:id
+    "id": "0000-...-0001",                 // the application-scoped id, echoed back
+    "application": "sovisuplus",
+    "person_uid": "local-user1",           // the user who performed the action
+    "target_type": "DOCUMENT",
+    "target_uid": "00000000-...-00aa",
+    "path": "contributions",
+    "action_type": "UPDATE",
+    "status": "applied | failed",
+    "error_message": "string | null",      // hard failure cause (status=failed)
+    "warnings": [                          // per-item losses (may be non-empty on applied)
+      {
+        "code": "UNRESOLVABLE_PERSON",
+        "message": "Skipping contribution with unresolvable person",
+        "context": { "display_name": "Claire Durand" }
+      }
+    ],
+    "timestamp": "2026-01-01T09:00:00Z"    // when the outcome was recorded
+  }
+}
+```
+
+Notes:
+
+- `event: applied` with a non-empty `warnings` array is the "partial success" case —
+  sovisuplus can show *"saved, but 1 contributor could not be resolved"*.
+- The payload deliberately does **not** carry document data; sovisuplus resyncs through the
+  existing document-updated message / GraphQL as today.
+- No document lookup is needed to build the payload — everything comes from the `Change`
+  node — so the factory is trivial and works even when the target document is broken.
+- `warnings[].context` echoes user-submitted data (names, identifiers) for display; there is
+  no message-size constraint on the graph exchange.
+
+#### Warning taxonomy (initial)
+
+| code | source | context fields |
+|---|---|---|
+| `UNRESOLVABLE_PERSON` | contribution skipped, person could not be resolved | `display_name`, `identifiers` |
+| `EXTERNAL_PERSON_CREATION_FAILED` | `ConflictError`/`ValueError` on person create | `display_name`, `error` |
+| `MISSING_DISPLAY_NAME` | external person without display name | `identifiers` |
+| `AFFILIATION_CONFLICT` | `ConflictError` on authority resolution | `source_organization_uid`, `error` |
+| `AFFILIATION_WITHOUT_IDENTIFIER` | affiliation with no usable identifier | `affiliation` |
+
+The taxonomy is open — codes are plain strings in the message contract; new processors add
+their own codes.
+
+### C. Collecting warnings — a change application report
+
+Change processors currently return `None` from `apply()` and services log-and-continue.
+Introduce a small report object threaded through the apply path:
+
+- `ChangeApplicationReport` (new model, e.g. `app/models/change_report.py`): a list of
+  `ChangeWarning(code, message, context: dict)` entries.
+- `AbstractChangeProcessor.apply()` returns a `ChangeApplicationReport` (empty list = clean
+  success). Existing processors return an empty report unchanged.
+- `ContributionUpdateService.reconcile(...)` accepts/returns the report and **appends a
+  warning at every point where it currently logs and skips** (the five sites listed above).
+  Logging stays; the report is additional, not a replacement.
+- `ChangeService.apply_change`:
+  - on success: persist the report on the `Change` node (see D), then — in interactive mode —
+    emit `change.applied`, and emit the existing `document_updated` as today;
+  - on failure: persist status + `error_message` as today, then — in interactive mode —
+    emit `change.failed` before re-raising.
+
+### D. Safety guard — an all-skipped reconcile is a hard failure
+
+If the submitted contribution list is **non-empty** but every contribution was skipped (the
+resolved list ends up empty), `ContributionUpdateService.reconcile` must **raise** instead of
+proceeding — otherwise `delete_contributions_not_in` would wipe every contributor from the
+document on the strength of a fully-failed resolution. The raised error follows the hard
+failure path: `status=FAILED`, `error_message` set, `change.failed` emitted, previous graph
+state untouched. An intentionally empty submitted list ("remove all contributors") is still
+applied as before.
+
+### E. Recording on the Change node
+
+Extend the `Change` model and Cypher queries:
+
+- `Change.warnings: list[ChangeWarning]` (default `[]`), marshalled to a JSON string for
+  storage (same pattern as `parameters` / `marshal_parameters`), property `warnings` on the
+  node;
+- `update_change_status.cypher` and `create_document_change.cypher` set `warnings` alongside
+  `status` / `error_message`;
+- `ChangeDAO._hydrate` unmarshals it (a `field_validator` on the model, mirroring
+  `_unmarshal_parameters`).
+
+No new status value: `status=applied` + non-empty `warnings` **is** the partial-success case;
+the replay logic (`create_and_apply_change` checks `status == APPLIED`) stays simple.
+
+### F. Signal wiring
+
+Follow the existing pattern (`app/signals.py` → `CrisalidIKG.__init__` →
+`AMQPInterface` → factory):
+
+- two new signals: `change_applied = signal('change-applied')` and
+  `change_failed = signal('change-failed')` — matching the created/updated/deleted
+  granularity used everywhere else, and letting sovisuplus bind failure handling to its own
+  queue if desired;
+- `ChangeService` sends them with `change=<Change>` (interactive mode only);
+- `AMQPInterface.dispatch_change_applied / dispatch_change_failed` → new
+  `AMQPChangeEventMessageFactory` (payload built purely from the `Change` object passed in
+  the signal — unlike the document factories, no DB round-trip);
+- register the new `EventMessageSubtype.CHANGE_APPLIED / CHANGE_FAILED` in
+  `AMQPMessagePublisher`.
+
+### G. Failures that occur before a Change exists
+
+Two pre-persistence failures currently leave no trace:
+
+1. **Validation failure** (`Change.model_validate` raises) — we cannot build a `Change`, but
+   the raw payload still carries `id`, `application`, `personUid`, `targetUid`. Emit a
+   `change.failed` event built from those raw fields with
+   `error_message = "invalid message: ..."`. No `Change` node is written (nothing valid to
+   write).
+2. **Target does not exist** (`create_change` raises `ValueError`) — the `Change` object
+   exists in memory; set `status=FAILED` + `error_message` and emit `change.failed`. The node
+   is **not** persisted: it cannot be linked to the missing document via `HAS_CHANGE`, and an
+   unlinked node would pollute the graph — the emitted event + logs are the record.
+
+Practically this means `AMQPUserActionsMessageProcessor._process_registered_change` (or
+`create_and_apply_change`) gains a try/except that guarantees a `change.failed` event on any
+`ValueError`/`DatabaseError`, instead of letting the exception silently die in the worker
+loop.
+
+### H. Batch replay (`apply_changes_to_node`)
+
+Replayed changes (after a document remerge) go through the same `apply_change`, but with
+`MessageMode.BATCH`: **no change event is emitted** — batch replays stay silent toward
+clients. `apply_changes_to_node` continues to swallow exceptions per change (one bad change
+must not block the others), and each failure still updates `status` / `error_message` /
+`warnings` on the `Change` node, so the outcome remains recorded in the graph.
+
+## Included fix
+
+`ChangeService.create_and_apply_change` has a pre-existing bug: when
+`existing.status == FAILED` it logs *"Retrying."* and then `return`s without retrying
+(`change_service.py:38-40`). Fix it here — the retry must clear `error_message` / `warnings`
+before re-applying, which interacts directly with this feature.
+
+## Out of scope
+
+- Unregistered actions (`FETCH`, person-`ADD`): no `Change` node, errors still vanish;
+  tracked separately.
+- The sovisuplus side (consuming the new events, unfreezing, toasting the user, displaying
+  warnings) is a separate spec in the sovisuplus repo.

--- a/specs/improve-error-reporting-for-user-actions#402/prompt.md
+++ b/specs/improve-error-reporting-for-user-actions#402/prompt.md
@@ -144,6 +144,8 @@ Notes:
 | `UNRESOLVABLE_PERSON` | contribution skipped, person could not be resolved | `display_name`, `identifiers` |
 | `EXTERNAL_PERSON_CREATION_FAILED` | `ConflictError`/`ValueError` on person create | `display_name`, `error` |
 | `MISSING_DISPLAY_NAME` | external person without display name | `identifiers` |
+| `INVALID_IDENTIFIER` | identifier with unknown type or value not matching the type pattern, dropped before any write | `type`, `value`, `display_name` |
+| `CONTRIBUTION_NOT_CREATED` | contribution creation returned no id | `person_uid` |
 | `AFFILIATION_CONFLICT` | `ConflictError` on authority resolution | `source_organization_uid`, `error` |
 | `AFFILIATION_WITHOUT_IDENTIFIER` | affiliation with no usable identifier | `affiliation` |
 

--- a/tests/test_services/test_change_error_reporting.py
+++ b/tests/test_services/test_change_error_reporting.py
@@ -1,0 +1,305 @@
+# file: tests/test_services/test_change_error_reporting.py
+import asyncio
+import json
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from app.amqp.amqp_user_actions_message_processor import AMQPUserActionsMessageProcessor
+from app.amqp.message_mode import MessageMode
+from app.config import get_app_settings
+from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
+from app.models.change import Change, TargetType, ChangeStatus
+from app.models.document import Document
+from app.models.people import Person
+from app.services.changes.change_service import ChangeService
+
+AUT = "http://id.loc.gov/vocabulary/relators/aut"
+
+
+@pytest.fixture(name="mocked_document_updated_signal")
+def mocked_document_updated_signal_fixture():
+    """Mock the `document_updated` signal."""
+    with patch("app.signals.document_updated.send_async", new_callable=AsyncMock) as mocked_signal:
+        yield mocked_signal
+
+
+@pytest.fixture(name="mocked_change_applied_signal")
+def mocked_change_applied_signal_fixture():
+    """Mock the `change_applied` signal."""
+    with patch("app.signals.change_applied.send_async", new_callable=AsyncMock) as mocked_signal:
+        yield mocked_signal
+
+
+@pytest.fixture(name="mocked_change_failed_signal")
+def mocked_change_failed_signal_fixture():
+    """Mock the `change_failed` signal."""
+    with patch("app.signals.change_failed.send_async", new_callable=AsyncMock) as mocked_signal:
+        yield mocked_signal
+
+
+def _contributions_change(document_uid: str, contributions: list[dict],
+                          uid: str = "sovisuplus:err1",
+                          change_id: str = "err1",
+                          timestamp: str = "2026-01-01T09:00:00Z") -> Change:
+    return Change(
+        uid=uid,
+        target_uid=document_uid,
+        target_type=TargetType.DOCUMENT,
+        person_uid="local-user1",
+        application="sovisuplus",
+        id=change_id,
+        action_type="UPDATE",
+        path="contributions",
+        parameters={"contributions": contributions},
+        timestamp=timestamp,
+    )
+
+
+async def _contributor_uids(document_uid: str) -> set:
+    document_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Document)
+    document = await document_dao.get_document_by_uid(document_uid)
+    return {contribution.contributor.uid for contribution in document.contributions}
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_records_warnings_and_emits_applied_event(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        persisted_person_a_pydantic_model: Person,
+        mocked_document_updated_signal,  # pylint: disable=unused-argument
+        mocked_change_applied_signal,
+        mocked_change_failed_signal) -> None:
+    """
+    Given a contributions change where one person resolves and one cannot be created
+        (no display name),
+    When the change is applied,
+    Then the change is APPLIED with a warning, the warning is persisted on the Change node,
+        and the change_applied event carries the warning.
+    """
+    document = document_hal_article_a_persisted_model
+    internal = persisted_person_a_pydantic_model
+
+    contributions = [
+        {"rank": 0, "roles": [AUT],
+         "person": {"uid": internal.uid, "displayName": internal.display_name,
+                    "identifiers": []},
+         "affiliations": []},
+        {"rank": 1, "roles": [AUT],
+         "person": {"uid": None, "displayName": None,
+                    "identifiers": [{"type": "orcid", "value": "0000-0000-0000-0099"}]},
+         "affiliations": []},
+    ]
+    service = ChangeService()
+    change = _contributions_change(document.uid, contributions)
+    await service.create_and_apply_change(change)
+
+    assert await _contributor_uids(document.uid) == {internal.uid}
+
+    change_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Change)
+    stored = await change_dao.get_by_uid(change.uid)
+    assert stored.status == ChangeStatus.APPLIED
+    assert [warning.code for warning in stored.warnings] == ["MISSING_DISPLAY_NAME"]
+
+    mocked_change_applied_signal.assert_called_once()
+    fields = mocked_change_applied_signal.call_args.kwargs["fields"]
+    assert fields["uid"] == change.uid
+    assert fields["person_uid"] == "local-user1"
+    assert fields["target_uid"] == document.uid
+    assert fields["status"] == "applied"
+    assert fields["warnings"][0]["code"] == "MISSING_DISPLAY_NAME"
+    mocked_change_failed_signal.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_safety_guard_aborts_all_skipped_reconcile(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        mocked_document_updated_signal,
+        mocked_change_applied_signal,
+        mocked_change_failed_signal) -> None:
+    """
+    Given a non-empty contributions list where no contribution can be applied,
+    When the change is applied,
+    Then a ValueError is raised, the previous contributors are kept,
+        the change is FAILED and a change_failed event is emitted.
+    """
+    document = document_hal_article_a_persisted_model
+    before = await _contributor_uids(document.uid)
+    assert before
+
+    contributions = [
+        {"rank": 0, "roles": [AUT],
+         "person": {"uid": None, "displayName": None, "identifiers": []},
+         "affiliations": []},
+    ]
+    service = ChangeService()
+    change = _contributions_change(document.uid, contributions,
+                                   uid="sovisuplus:guard1", change_id="guard1")
+
+    with pytest.raises(ValueError, match="aborting to avoid removing all contributors"):
+        await service.create_and_apply_change(change)
+
+    assert await _contributor_uids(document.uid) == before
+
+    change_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Change)
+    stored = await change_dao.get_by_uid(change.uid)
+    assert stored.status == ChangeStatus.FAILED
+    assert "aborting to avoid removing all contributors" in stored.error_message
+
+    mocked_change_failed_signal.assert_called_once()
+    fields = mocked_change_failed_signal.call_args.kwargs["fields"]
+    assert fields["uid"] == change.uid
+    assert fields["status"] == "failed"
+    assert "aborting" in fields["error_message"]
+    mocked_change_applied_signal.assert_not_called()
+    mocked_document_updated_signal.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_target_document_emits_failed_event_without_node(
+        test_app,  # pylint: disable=unused-argument
+        mocked_change_applied_signal,
+        mocked_change_failed_signal) -> None:
+    """
+    Given a change targeting a non-existent document,
+    When the change is submitted,
+    Then a change_failed event is emitted and no Change node is persisted.
+    """
+    service = ChangeService()
+    change = _contributions_change("nonexistent-document-uid", [],
+                                   uid="sovisuplus:missing1", change_id="missing1")
+
+    with pytest.raises(ValueError, match="does not exist"):
+        await service.create_and_apply_change(change)
+
+    mocked_change_failed_signal.assert_called_once()
+    fields = mocked_change_failed_signal.call_args.kwargs["fields"]
+    assert fields["uid"] == change.uid
+    assert fields["status"] == "failed"
+    assert "does not exist" in fields["error_message"]
+    mocked_change_applied_signal.assert_not_called()
+
+    change_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Change)
+    assert await change_dao.get_by_uid(change.uid) is None
+
+
+@pytest.mark.asyncio
+async def test_failed_change_is_retried(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        mocked_document_updated_signal,  # pylint: disable=unused-argument
+        mocked_change_applied_signal,
+        mocked_change_failed_signal) -> None:
+    """
+    Given a change that failed on first application,
+    When the same change is submitted again,
+    Then it is re-applied (not skipped): the second attempt fails again here,
+        producing a second change_failed event.
+    """
+    document = document_hal_article_a_persisted_model
+    change = Change(
+        uid="sovisuplus:retry1",
+        target_uid=document.uid,
+        target_type=TargetType.DOCUMENT,
+        person_uid="local-user1",
+        application="sovisuplus",
+        id="retry1",
+        action_type="UPDATE",
+        path="documentType",
+        parameters={"value": "Not_a_correct_type"},
+        timestamp="2026-01-01T09:00:00Z",
+    )
+    service = ChangeService()
+
+    with pytest.raises(ValueError):
+        await service.create_and_apply_change(change)
+    assert mocked_change_failed_signal.call_count == 1
+
+    retried = Change.model_validate(change.model_dump() | {"status": ChangeStatus.CREATED})
+    with pytest.raises(ValueError):
+        await service.create_and_apply_change(retried)
+    assert mocked_change_failed_signal.call_count == 2
+    mocked_change_applied_signal.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_batch_replay_stays_silent(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        persisted_person_a_pydantic_model: Person,
+        mocked_document_updated_signal,  # pylint: disable=unused-argument
+        mocked_change_applied_signal,
+        mocked_change_failed_signal) -> None:
+    """
+    Given a stored change replayed in batch mode (after a remerge),
+    When apply_changes_to_node runs,
+    Then no change event is emitted toward clients.
+    """
+    document = document_hal_article_a_persisted_model
+    internal = persisted_person_a_pydantic_model
+    change = _contributions_change(
+        document.uid,
+        [{"rank": 0, "roles": [AUT],
+          "person": {"uid": internal.uid, "displayName": internal.display_name,
+                     "identifiers": []},
+          "affiliations": []}],
+        uid="sovisuplus:batch1", change_id="batch1")
+    change_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Change)
+    await change_dao.create_document_change(document, change)
+
+    await ChangeService().apply_changes_to_node(document.uid, mode=MessageMode.BATCH)
+
+    assert (await change_dao.get_by_uid(change.uid)).status == ChangeStatus.APPLIED
+    mocked_change_applied_signal.assert_not_called()
+    mocked_change_failed_signal.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invalid_message_emits_failed_event(
+        test_app,  # pylint: disable=unused-argument
+        mocked_change_failed_signal) -> None:
+    """
+    Given a user-action message that cannot be validated into a Change (missing id),
+    When the message is processed,
+    Then a change_failed event is emitted with the raw correlation fields.
+    """
+    payload = {
+        # "id" missing: Change validation fails
+        "actionType": "UPDATE",
+        "targetType": "DOCUMENT",
+        "targetUid": "some-document-uid",
+        "path": "contributions",
+        "parameters": {"contributions": []},
+        "personUid": "local-user1",
+        "application": "sovisuplus",
+        "timestamp": "2026-01-01T09:00:00Z",
+    }
+    processor = AMQPUserActionsMessageProcessor(asyncio.Queue(), get_app_settings())
+
+    with pytest.raises(ValueError, match="Failed to build Change object"):
+        # pylint: disable=protected-access
+        await processor._process_message(
+            "task.documents.document.update", json.dumps(payload).encode("utf-8"))
+
+    mocked_change_failed_signal.assert_called_once()
+    fields = mocked_change_failed_signal.call_args.kwargs["fields"]
+    assert fields["person_uid"] == "local-user1"
+    assert fields["target_uid"] == "some-document-uid"
+    assert fields["status"] == "failed"
+    assert fields["error_message"].startswith("invalid message")
+
+
+def test_change_warnings_marshalling_round_trip() -> None:
+    """Warnings survive a marshal/unmarshal round trip (as stored on the Change node)."""
+    change = _contributions_change("doc-1", [])
+    change.warnings = []
+    stored = change.marshal_warnings()
+    assert stored == "[]"
+
+    change = Change.model_validate({
+        **change.model_dump(exclude={"warnings"}),
+        "warnings": json.dumps([{"code": "X", "message": "m", "context": {"a": 1}}]),
+    })
+    assert change.warnings[0].code == "X"
+    assert change.warnings[0].context == {"a": 1}

--- a/tests/test_services/test_change_error_reporting.py
+++ b/tests/test_services/test_change_error_reporting.py
@@ -9,6 +9,7 @@ from app.amqp.amqp_user_actions_message_processor import AMQPUserActionsMessageP
 from app.amqp.message_mode import MessageMode
 from app.config import get_app_settings
 from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
+from app.graph.neo4j.neo4j_connexion import Neo4jConnexion
 from app.models.change import Change, TargetType, ChangeStatus
 from app.models.document import Document
 from app.models.people import Person
@@ -60,6 +61,16 @@ async def _contributor_uids(document_uid: str) -> set:
     document_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Document)
     document = await document_dao.get_document_by_uid(document_uid)
     return {contribution.contributor.uid for contribution in document.contributions}
+
+
+async def _agent_identifiers(person_uid: str) -> set:
+    query = ("MATCH (:Person {uid: $uid})-[:HAS_IDENTIFIER]->(i:AgentIdentifier) "
+             "RETURN collect([i.type, i.value]) AS ids")
+    async with Neo4jConnexion().get_driver() as driver:
+        async with driver.session() as session:
+            result = await session.run(query, uid=person_uid)
+            record = await result.single()
+            return {(t, v) for t, v in record["ids"]}
 
 
 @pytest.mark.asyncio
@@ -288,6 +299,133 @@ async def test_invalid_message_emits_failed_event(
     assert fields["target_uid"] == "some-document-uid"
     assert fields["status"] == "failed"
     assert fields["error_message"].startswith("invalid message")
+
+
+@pytest.mark.asyncio
+async def test_invalid_identifier_only_reports_real_cause(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        persisted_person_a_pydantic_model: Person,
+        mocked_document_updated_signal,  # pylint: disable=unused-argument
+        mocked_change_applied_signal) -> None:
+    """
+    Given a new person whose only identifier is an invalid idhals (digits),
+    When the change is applied,
+    Then the warnings name the invalid identifier explicitly, and the creation-failure
+        error is the informative uid message (no model dump).
+    """
+    document = document_hal_article_a_persisted_model
+    internal = persisted_person_a_pydantic_model
+
+    contributions = [
+        {"rank": 0, "roles": [AUT],
+         "person": {"uid": internal.uid, "displayName": internal.display_name,
+                    "identifiers": []},
+         "affiliations": []},
+        {"rank": 1, "roles": [AUT],
+         "person": {"uid": None, "displayName": "Laurent Touquet",
+                    "identifiers": [{"type": "idhals", "value": "123456"}]},
+         "affiliations": []},
+    ]
+    change = _contributions_change(document.uid, contributions,
+                                   uid="sovisuplus:badid1", change_id="badid1")
+    await ChangeService().create_and_apply_change(change)
+
+    change_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Change)
+    stored = await change_dao.get_by_uid(change.uid)
+    assert stored.status == ChangeStatus.APPLIED
+    codes = [warning.code for warning in stored.warnings]
+    assert codes == ["INVALID_IDENTIFIER", "EXTERNAL_PERSON_CREATION_FAILED"]
+
+    invalid = stored.warnings[0]
+    assert invalid.context["type"] == "idhals"
+    assert invalid.context["value"] == "123456"
+    assert invalid.context["display_name"] == "Laurent Touquet"
+
+    creation_failed = stored.warnings[1]
+    assert "Cannot compute uid for Person" in creation_failed.context["error"]
+    assert "model" not in creation_failed.context["error"]
+
+    fields = mocked_change_applied_signal.call_args.kwargs["fields"]
+    assert [warning["code"] for warning in fields["warnings"]] == codes
+
+
+@pytest.mark.asyncio
+async def test_invalid_identifier_dropped_on_person_creation(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        mocked_document_updated_signal,  # pylint: disable=unused-argument
+        mocked_change_applied_signal) -> None:  # pylint: disable=unused-argument
+    """
+    Given a new person with a valid orcid and an invalid idhals,
+    When the change is applied,
+    Then the person is created from the valid identifier only, and the invalid one is
+        reported and not persisted.
+    """
+    document = document_hal_article_a_persisted_model
+    contributions = [
+        {"rank": 0, "roles": [AUT],
+         "person": {"uid": None, "displayName": "Claire Durand",
+                    "identifiers": [{"type": "orcid", "value": "0000-0000-0000-0003"},
+                                    {"type": "idhals", "value": "123456"}]},
+         "affiliations": []},
+    ]
+    change = _contributions_change(document.uid, contributions,
+                                   uid="sovisuplus:badid2", change_id="badid2")
+    await ChangeService().create_and_apply_change(change)
+
+    assert await _contributor_uids(document.uid) == {"orcid-0000-0000-0000-0003"}
+
+    change_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Change)
+    stored = await change_dao.get_by_uid(change.uid)
+    assert stored.status == ChangeStatus.APPLIED
+    assert [warning.code for warning in stored.warnings] == ["INVALID_IDENTIFIER"]
+
+    identifiers = await _agent_identifiers("orcid-0000-0000-0000-0003")
+    assert ("orcid", "0000-0000-0000-0003") in identifiers
+    assert not any(id_type == "idhals" for id_type, _ in identifiers)
+
+
+@pytest.mark.asyncio
+async def test_invalid_identifier_not_merged_on_existing_external_person(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        mocked_document_updated_signal,  # pylint: disable=unused-argument
+        mocked_change_applied_signal) -> None:  # pylint: disable=unused-argument
+    """
+    Given an existing external person and incoming identifiers containing an invalid idhals,
+    When the change is applied,
+    Then the invalid identifier is reported and not written onto the person.
+    """
+    document = document_hal_article_a_persisted_model
+    person_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Person)
+    external = Person(uid="orcid-0000-0002-7428-4209", display_name="Bernard Chevalier",
+                      external=True,
+                      identifiers=[{"type": "orcid", "value": "0000-0002-7428-4209"}])
+    await person_dao.create(external)
+
+    contributions = [
+        {"rank": 0, "roles": [AUT],
+         "person": {"uid": external.uid, "displayName": external.display_name,
+                    "identifiers": [{"type": "orcid", "value": "0000-0002-7428-4209"},
+                                    {"type": "idhals", "value": "987654"}]},
+         "affiliations": []},
+    ]
+    change = _contributions_change(document.uid, contributions,
+                                   uid="sovisuplus:badid3", change_id="badid3")
+    await ChangeService().create_and_apply_change(change)
+
+    assert await _contributor_uids(document.uid) == {external.uid}
+
+    change_dao = AbstractDAOFactory().get_dao_factory("neo4j").get_dao(Change)
+    stored = await change_dao.get_by_uid(change.uid)
+    assert stored.status == ChangeStatus.APPLIED
+    assert [warning.code for warning in stored.warnings] == ["INVALID_IDENTIFIER"]
+    assert stored.warnings[0].context["value"] == "987654"
+
+    identifiers = await _agent_identifiers(external.uid)
+    assert ("orcid", "0000-0002-7428-4209") in identifiers
+    assert not any(id_type == "idhals" for id_type, _ in identifiers)
 
 
 def test_change_warnings_marshalling_round_trip() -> None:

--- a/tests/test_services/test_contribution_update_service.py
+++ b/tests/test_services/test_contribution_update_service.py
@@ -252,6 +252,28 @@ async def test_reconcile_resolves_existing_external_person_by_uid(
 
 
 @pytest.mark.asyncio
+async def test_external_person_created_from_idhals_only(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        mocked_document_updated_signal) -> None:  # pylint: disable=unused-argument
+    """
+    A brand-new person whose only identifier is a valid idHal (string form) is created
+    as an external person keyed on it (idhals is part of the person identifier order).
+    """
+    document = document_hal_article_a_persisted_model
+    contributions = [{
+        "rank": 0, "roles": [AUT],
+        "person": {"uid": None, "displayName": "Laurent Touquet",
+                   "identifiers": [{"type": "idhals", "value": "laurent-touquet"}]},
+        "affiliations": [],
+    }]
+    await ChangeService().create_and_apply_change(
+        _contributions_change(document.uid, contributions))
+
+    assert await _contributor_uids(document.uid) == {"idhals-laurent-touquet"}
+
+
+@pytest.mark.asyncio
 async def test_repoints_to_internal_owner_of_aligned_identifier(
         test_app,  # pylint: disable=unused-argument
         document_hal_article_a_persisted_model: Document,


### PR DESCRIPTION
- collect per-item warnings in a ChangeApplicationReport and persist them on the Change node
- emit change.applied / change.failed events (interactive only) with correlation fields
- safety guard: abort contribution reconcile when nothing resolves
- emit change.failed for invalid messages and missing target documents
- fix retry of previously failed changes