### PR TITLE
fix: loguru exc_info misuse destroys error logs

### DIFF
--- a/app/amqp/amqp_interface.py
+++ b/app/amqp/amqp_interface.py
@@ -177,8 +177,9 @@ class AMQPInterface:
                     logger.debug(f"Message added to inner queue for topic: {topic}")
         # pylint: disable=broad-except
         except Exception as e:
-            logger.error(f"Error while listening to messages on topic '{topic}': {e}",
-                         exc_info=True)
+            logger.opt(exception=True).error(
+                "Error while listening to messages on topic '{}': {}", topic, e
+            )
 
     async def _declare_exchange(self, exchange_name: str, with_dlx=False) -> None:
         if exchange_name in self.pika_exchanges:

--- a/app/amqp/amqp_message_processor.py
+++ b/app/amqp/amqp_message_processor.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import traceback
 from abc import ABC, abstractmethod
 from datetime import datetime
 
@@ -47,16 +46,14 @@ class AMQPMessageProcessor(ABC):
                         await message.ack()
                     # inner exceptions
                     except ValueError as error:
-                        logger.error(
-                            f"Invalid message received by {worker_id} : {error}",
-                            exc_info=True
+                        logger.opt(exception=True).error(
+                            "Invalid message received by {} : {}", worker_id, error
                         )
                     except DatabaseError as database_error:
-                        logger.error(traceback.format_exc())
-                        logger.error(
-                            f"Database error for worker {worker_id} "
-                            f"message processing : {database_error}",
-                            exc_info=True
+                        logger.opt(exception=True).error(
+                            "Database error for worker {} message processing : {}",
+                            worker_id,
+                            database_error,
                         )
                         requeue = True
                     finally:
@@ -68,11 +65,11 @@ class AMQPMessageProcessor(ABC):
                 await message.nack(requeue=True)
                 raise keyboard_interrupt
             except Exception as exception:  # pylint: disable=broad-exception-caught
-                logger.error(
-                    f"Unexpected exception during {worker_id} message processing: {exception}",
-                    exc_info=True
+                logger.opt(exception=True).error(
+                    "Unexpected exception during {} message processing: {}",
+                    worker_id,
+                    exception,
                 )
-                logger.error(traceback.format_exc())
             finally:
                 self.tasks_queue.task_done()
                 await asyncio.sleep(0)

--- a/app/amqp/amqp_reference_message_processor.py
+++ b/app/amqp/amqp_reference_message_processor.py
@@ -90,8 +90,10 @@ class AMQReferenceMessageProcessor(AMQPMessageProcessor):
                     await self._update_source_record(source_record, person, identifier_used,
                                                      mode=mode, first_attempt=False)
                     return
-                logger.error(f"Aborting update attempt for {source_record.uid}"
-                             f" after failed create attempt", exc_info=True)
+                logger.opt(exception=True).error(
+                    "Aborting update attempt for {} after failed create attempt",
+                    source_record.uid,
+                )
                 return
             await self.service.create_source_record(source_record=source_record,
                                                     harvested_for=person,
@@ -105,7 +107,9 @@ class AMQReferenceMessageProcessor(AMQPMessageProcessor):
         except ConflictError as e:
             logger.warning(
                 f"Identifier conflict while trying to create source record {source_record} : {e}")
-            logger.error(f"{source_record.uid} already exists in the database", exc_info=True)
+            logger.opt(exception=True).error(
+                "{} already exists in the database", source_record.uid
+            )
         except DatabaseError as e:
             logger.error(
                 f"Database error while trying to create source record {source_record} : {e}")
@@ -127,8 +131,10 @@ class AMQReferenceMessageProcessor(AMQPMessageProcessor):
                     await self._create_source_record(source_record, person, identifier_used,
                                                      mode=mode, first_attempt=False)
                 else:
-                    logger.error(f"Aborting create attempt for {source_record.uid}"
-                                 f" after failed update attempt", exc_info=True)
+                    logger.opt(exception=True).error(
+                        "Aborting create attempt for {} after failed update attempt",
+                        source_record.uid,
+                    )
         except ReferenceOwnerNotFoundError as e:
             logger.error(
                 f"Reference owner {person} not found while trying to update source record"


### PR DESCRIPTION
- loguru has no `exc_info` parameter: any extra kwarg makes it call `str.format()` on the already-interpolated message, so payloads containing braces (e.g. pydantic validation errors embedding the input dict) raised `KeyError` inside the error handler and the original log line was lost
- replaced with `logger.opt(exception=True).error(...)` and format-args style, which also actually logs the traceback as intended
- removed now-redundant `traceback.format_exc()` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)