### PR TITLE
feat: first-class DoctoralSchool organization type

### DIFF
--- a/app/graph/neo4j/neo4j_setup.py
+++ b/app/graph/neo4j/neo4j_setup.py
@@ -44,6 +44,7 @@ class Neo4jSetup(Setup[AsyncDriver]):
         await cls._create_structured_physical_address_uid_constraint(tx)
         await cls._create_place_lat_lon_unique_constraint(tx)
         await cls._create_research_unit_uid_unique_constraint(tx)
+        await cls._create_doctoral_school_uid_unique_constraint(tx)
         await cls._create_publication_identifier_unique_type_value_constraint(tx)
         await cls._create_source_issue_unique_source_identifier_source_constraint(tx)
         await cls._create_authority_organization_state_signature_constraint(tx)
@@ -315,6 +316,24 @@ class Neo4jSetup(Setup[AsyncDriver]):
         except DatabaseError as e:
             logger.error(
                 "Error creating ResearchUnit uid unique constraint: "
+                f"{e}"
+            )
+            raise e
+
+    @staticmethod
+    async def _create_doctoral_school_uid_unique_constraint(
+            tx: AsyncManagedTransaction
+    ):
+        query = """
+        CREATE CONSTRAINT doctoral_school_uid_unique IF NOT EXISTS
+        FOR (d:DoctoralSchool)
+        REQUIRE d.uid IS UNIQUE;
+        """
+        try:
+            await tx.run(query=query)
+        except DatabaseError as e:
+            logger.error(
+                "Error creating DoctoralSchool uid unique constraint: "
                 f"{e}"
             )
             raise e

--- a/app/graph/neo4j/organization_unit_dao.py
+++ b/app/graph/neo4j/organization_unit_dao.py
@@ -11,6 +11,7 @@ from app.graph.neo4j.utils import load_query
 from app.models.identifier_types import OrganizationIdentifierType
 from app.models.organization_unit import (
     AdministrativeUnit,
+    DoctoralSchool,
     Institution,
     InstitutionSubdivision,
     OrganizationBase,
@@ -260,6 +261,8 @@ class OrganizationUnitDAO(Neo4jDAO):
             labels.append("Institution")
         elif isinstance(org_unit, InstitutionSubdivision):
             labels.append("InstitutionSubdivision")
+        elif isinstance(org_unit, DoctoralSchool):
+            labels.append("DoctoralSchool")
         elif isinstance(org_unit, UnitSubdivision):
             labels.append("UnitSubdivision")
         elif isinstance(org_unit, Team):

--- a/app/graph/neo4j/queries/create_membership.cypher
+++ b/app/graph/neo4j/queries/create_membership.cypher
@@ -1,3 +1,3 @@
 MATCH (p:Person {uid: $person_uid})
-MATCH (s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Team {uid: $structure_uid})
+MATCH (s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|DoctoralSchool|TeachingUnit|Team {uid: $structure_uid})
 CREATE (p)-[:MEMBER_OF]->(s)

--- a/app/graph/neo4j/queries/delete_person_memberships.cypher
+++ b/app/graph/neo4j/queries/delete_person_memberships.cypher
@@ -1,2 +1,2 @@
-MATCH (p:Person {uid: $person_uid})-[r:MEMBER_OF]->(s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Team)
+MATCH (p:Person {uid: $person_uid})-[r:MEMBER_OF]->(s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|DoctoralSchool|TeachingUnit|Team)
 DELETE r

--- a/app/graph/neo4j/queries/find_person_by_identifier.cypher
+++ b/app/graph/neo4j/queries/find_person_by_identifier.cypher
@@ -2,7 +2,7 @@ MATCH (person:Person)-[:HAS_IDENTIFIER]->(filter:AgentIdentifier {type: $identif
 OPTIONAL MATCH (person)-[:HAS_NAME]->(pn:PersonName)
 OPTIONAL MATCH (pn)-[:HAS_FIRST_NAME]->(fn:Literal {type: 'person_first_name'})
 OPTIONAL MATCH (pn)-[:HAS_LAST_NAME]->(ln:Literal {type: 'person_last_name'})
-OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Team)
+OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|DoctoralSchool|TeachingUnit|Team)
 OPTIONAL MATCH (person)-[emp:EMPLOYED_AT]->(inst:Institution)
 WITH person, pn, fn, ln, mb, rs, emp, inst
 MATCH (person)-[:HAS_IDENTIFIER]->(id:AgentIdentifier)

--- a/app/graph/neo4j/queries/get_person_by_uid.cypher
+++ b/app/graph/neo4j/queries/get_person_by_uid.cypher
@@ -2,7 +2,7 @@ MATCH (person:Person {uid: $person_uid})
 OPTIONAL MATCH (person)-[:HAS_NAME]->(pn:PersonName)
 OPTIONAL MATCH (pn)-[:HAS_FIRST_NAME]->(fn:Literal {type: 'person_first_name'})
 OPTIONAL MATCH (pn)-[:HAS_LAST_NAME]->(ln:Literal {type: 'person_last_name'})
-OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Team)
+OPTIONAL MATCH (person)-[mb:MEMBER_OF]->(rs:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|DoctoralSchool|TeachingUnit|Team)
 OPTIONAL MATCH (person)-[emp:EMPLOYED_AT]->(inst:Institution)
 WITH person, pn, fn, ln, mb, rs, emp, inst
 OPTIONAL MATCH (person)-[:HAS_IDENTIFIER]->(id:AgentIdentifier)

--- a/app/graph/neo4j/queries/research_unit_exists_by_uid.cypher
+++ b/app/graph/neo4j/queries/research_unit_exists_by_uid.cypher
@@ -1,2 +1,2 @@
-MATCH (s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|TeachingUnit|Institution|Team {uid: $uid})
+MATCH (s:ResearchUnit|SupportUnit|AdministrativeUnit|InstitutionSubdivision|DoctoralSchool|TeachingUnit|Institution|Team {uid: $uid})
 RETURN s.uid AS uid LIMIT 1

--- a/app/models/organization_types.py
+++ b/app/models/organization_types.py
@@ -5,6 +5,7 @@ class GenericOrganizationType(str, Enum):
     """Top-level category of a research organization structure."""
     INSTITUTION = "institution"
     INSTITUTION_SUBDIVISION = "institution_subdivision"
+    DOCTORAL_SCHOOL = "doctoral_school"
     UNIT = "unit"
     UNIT_SUBDIVISION = "unit_subdivision"
     TEAM = "team"
@@ -24,6 +25,7 @@ class NationalOrganizationType(str, Enum):
     UFR = "UFR"
     FAC = "FAC"
     FDR = "FDR"
+    ED = "ED"
     TEAM = "TEAM"
     THEME = "THEME"
 
@@ -61,6 +63,9 @@ ALLOWED_NATIONAL_TYPES_BY_GENERIC_TYPE: dict = {
         NationalOrganizationType.UFR,
         NationalOrganizationType.FAC,
         NationalOrganizationType.FDR,
+    },
+    GenericOrganizationType.DOCTORAL_SCHOOL: {
+        NationalOrganizationType.ED,
     },
     GenericOrganizationType.UNIT_SUBDIVISION: set(),
     GenericOrganizationType.TEAM: {

--- a/app/models/organization_unit.py
+++ b/app/models/organization_unit.py
@@ -194,6 +194,13 @@ class InstitutionSubdivision(OrganizationBase):
     )
 
 
+class DoctoralSchool(OrganizationBase):
+    """A doctoral school attached to one or several institutions (ED…)."""
+    generic_type: TypingLiteral[GenericOrganizationType.DOCTORAL_SCHOOL] = (
+        GenericOrganizationType.DOCTORAL_SCHOOL
+    )
+
+
 class UnitSubdivision(OrganizationBase):
     """A subdivision of a research unit."""
     generic_type: TypingLiteral[GenericOrganizationType.UNIT_SUBDIVISION] = (
@@ -251,7 +258,7 @@ Unit = Annotated[
 ]
 
 NonUnitOrganizationUnit = Annotated[
-    Union[Institution, InstitutionSubdivision, UnitSubdivision, Team],
+    Union[Institution, InstitutionSubdivision, DoctoralSchool, UnitSubdivision, Team],
     Field(discriminator='generic_type'),
 ]
 

--- a/tests/data/organizations/doctoral_school_a.json
+++ b/tests/data/organizations/doctoral_school_a.json
@@ -1,0 +1,33 @@
+{
+  "generic_type": "doctoral_school",
+  "type": "ED",
+  "local_types": [],
+  "long_labels": [
+    {"value": "École doctorale d'arts plastiques, esthétique et sciences de l'art", "language": "fr"}
+  ],
+  "short_labels": [
+    {"value": "ED Arts plastiques", "language": "fr"}
+  ],
+  "descriptions": [
+    {"value": "École doctorale d'arts plastiques, esthétique et sciences de l'art", "language": "fr"}
+  ],
+  "identifiers": [
+    {"type": "local", "value": "EDO04"}
+  ],
+  "relationships": [
+    {
+      "type": "part_of",
+      "subtype": null,
+      "target": "local-EXAMPLE-UNIV-001",
+      "start_date": null,
+      "end_date": null
+    }
+  ],
+  "contacts": [
+    {
+      "type": "electronical_address",
+      "format": "website_address",
+      "value": {"uri": "https://ed-arts.pantheonsorbonne.fr/"}
+    }
+  ]
+}

--- a/tests/fixtures/organization_fixtures.py
+++ b/tests/fixtures/organization_fixtures.py
@@ -124,6 +124,27 @@ async def fixture_persisted_institution_subdivision_a_pydantic_model(
     return institution_subdivision_a_pydantic_model
 
 
+@pytest_asyncio.fixture(name="doctoral_school_a_json_data")
+async def fixture_doctoral_school_a_json_data(_base_path) -> dict:
+    return _organization_unit_json_data_from_file(_base_path, "doctoral_school_a")
+
+
+@pytest_asyncio.fixture(name="doctoral_school_a_pydantic_model")
+async def fixture_doctoral_school_a_pydantic_model(
+        doctoral_school_a_json_data) -> OrganizationBase:
+    return _organization_unit_from_json_data(doctoral_school_a_json_data)
+
+
+@pytest_asyncio.fixture(name="persisted_doctoral_school_a_pydantic_model")
+async def fixture_persisted_doctoral_school_a_pydantic_model(
+        doctoral_school_a_pydantic_model) -> OrganizationBase:
+    settings = get_app_settings()
+    factory = AbstractDAOFactory().get_dao_factory(settings.graph_db)
+    dao = factory.get_dao(OrganizationBase)
+    await dao.create(doctoral_school_a_pydantic_model)
+    return doctoral_school_a_pydantic_model
+
+
 @pytest_asyncio.fixture(name="research_unit_center_json_data")
 async def fixture_research_unit_center_json_data(_base_path) -> dict:
     return _organization_unit_json_data_from_file(_base_path, "research_unit_center")

--- a/tests/test_graph/test_organization_unit_dao.py
+++ b/tests/test_graph/test_organization_unit_dao.py
@@ -13,6 +13,7 @@ from app.models.organization_types import (
     OrgMembershipPosition,
 )
 from app.models.organization_unit import (
+    DoctoralSchool,
     Institution,
     InstitutionSubdivision,
     OrganizationBase,
@@ -178,6 +179,33 @@ async def test_create_institution_subdivision_with_part_of(
     retrieved = await dao.get(fac_uid)
     assert retrieved is not None
     assert isinstance(retrieved, InstitutionSubdivision)
+    assert len(retrieved.parents) == 1
+    assert retrieved.parents[0].target == "local-EXAMPLE-UNIV-001"
+
+
+async def test_create_doctoral_school_with_part_of(
+        test_app,
+        persisted_institution_a_pydantic_model: OrganizationBase,
+        doctoral_school_a_pydantic_model: OrganizationBase,
+):
+    dao = _get_dao()
+    await dao.create(doctoral_school_a_pydantic_model)
+
+    ed_uid = doctoral_school_a_pydantic_model.uid
+    assert ed_uid == "local-EDO04"
+
+    labels = await _node_labels(ed_uid)
+    assert "OrganizationUnit" in labels
+    assert "DoctoralSchool" in labels
+
+    rel_props = await _relationship_exists(ed_uid, "PART_OF", "local-EXAMPLE-UNIV-001")
+    assert rel_props is not None
+
+    retrieved = await dao.get(ed_uid)
+    assert retrieved is not None
+    assert isinstance(retrieved, DoctoralSchool)
+    assert retrieved.generic_type == GenericOrganizationType.DOCTORAL_SCHOOL
+    assert retrieved.national_type == NationalOrganizationType.ED
     assert len(retrieved.parents) == 1
     assert retrieved.parents[0].target == "local-EXAMPLE-UNIV-001"
 

--- a/tests/test_models/test_organization_unit.py
+++ b/tests/test_models/test_organization_unit.py
@@ -10,6 +10,7 @@ from app.models.organization_types import (
     OrgMembershipPosition,
 )
 from app.models.organization_unit import (
+    DoctoralSchool,
     Institution,
     InstitutionSubdivision,
     OrgInclusion,
@@ -43,6 +44,51 @@ def test_create_institution_subdivision_from_json(institution_subdivision_a_json
     assert parent.target == "local-EXAMPLE-UNIV-001"
     assert parent.start_date == date(2010, 1, 1)
     assert parent.end_date == date(2030, 12, 31)
+
+
+def test_create_doctoral_school_from_json(doctoral_school_a_json_data):
+    org = nonUnitAdapter.validate_python(doctoral_school_a_json_data)
+    assert isinstance(org, DoctoralSchool)
+    assert org.generic_type == GenericOrganizationType.DOCTORAL_SCHOOL
+    assert org.national_type == NationalOrganizationType.ED
+    assert len(org.parents) == 1
+    assert org.parents[0].target == "local-EXAMPLE-UNIV-001"
+    assert org.electronical_addresses[0].uri == "https://ed-arts.pantheonsorbonne.fr/"
+
+
+def test_create_doctoral_school_from_directory_message():
+    """A doctoral school event as sent by the directory bridge (no national type)."""
+    data = {
+        "contacts": [
+            {
+                "type": "electronical_address",
+                "value": {"uri": "https://ed-arts.pantheonsorbonne.fr/"},
+                "format": "website_address",
+            }
+        ],
+        "identifiers": [{"type": "local", "value": "EDO04"}],
+        "long_labels": [{"value": "ED Arts plastiques", "language": "fr"}],
+        "descriptions": [
+            {
+                "value": "École doctorale d'arts plastiques, esthétique "
+                         "et sciences de l'art",
+                "language": "fr",
+            }
+        ],
+        "generic_type": "doctoral_school",
+        "short_labels": [{"value": "ED Arts plastiques", "language": "fr"}],
+        "relationships": [{"type": "part_of", "target": "local-DGIB"}],
+    }
+    org = nonUnitAdapter.validate_python(data)
+    assert isinstance(org, DoctoralSchool)
+    assert org.national_type is None
+    assert org.parents[0].target == "local-DGIB"
+
+
+def test_doctoral_school_rejects_non_ed_national_type(doctoral_school_a_json_data):
+    doctoral_school_a_json_data["type"] = "UMR"
+    with pytest.raises(ValidationError):
+        nonUnitAdapter.validate_python(doctoral_school_a_json_data)
 
 
 def test_create_research_unit_from_json(research_unit_center_json_data):


### PR DESCRIPTION
Directory events with `generic_type: "doctoral_school"` (e.g. Paris 1 écoles doctorales) were rejected by the non-unit tagged union and dropped.

- add `DOCTORAL_SCHOOL` to `GenericOrganizationType` and `ED` to `NationalOrganizationType` (allowed national type for doctoral schools; events without a national type remain valid via labels)
- add `DoctoralSchool` Pydantic model to the non-unit discriminated union
- persist with `OrganizationUnit:DoctoralSchool` labels; add uid uniqueness constraint in `Neo4jSetup`
- include `DoctoralSchool` in person-membership label unions (create/delete memberships, person hydration, membership target existence check)
- fixtures + model/DAO tests, including the exact producer payload that was previously rejected

Note: DAO tests not run locally — the auth-none test Neo4j on port 7688 was unavailable (port occupied by an SSH tunnel to an authenticated instance); model layer verified offline against the real payload. CI should cover the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)