### PR TITLE
fix: allow GIS, GIP, LABEX, EUR national types for institution subdivisions

### DIFF
--- a/app/models/organization_types.py
+++ b/app/models/organization_types.py
@@ -26,6 +26,9 @@ class NationalOrganizationType(str, Enum):
     FAC = "FAC"
     FDR = "FDR"
     ED = "ED"
+    GIS = "GIS"
+    GIP = "GIP"
+    LABEX = "LABEX"
     TEAM = "TEAM"
     THEME = "THEME"
 
@@ -63,6 +66,10 @@ ALLOWED_NATIONAL_TYPES_BY_GENERIC_TYPE: dict = {
         NationalOrganizationType.UFR,
         NationalOrganizationType.FAC,
         NationalOrganizationType.FDR,
+        NationalOrganizationType.GIS,
+        NationalOrganizationType.GIP,
+        NationalOrganizationType.LABEX,
+        NationalOrganizationType.UR,
     },
     GenericOrganizationType.DOCTORAL_SCHOOL: {
         NationalOrganizationType.ED,

--- a/app/models/organization_types.py
+++ b/app/models/organization_types.py
@@ -71,7 +71,6 @@ ALLOWED_NATIONAL_TYPES_BY_GENERIC_TYPE: dict = {
         NationalOrganizationType.GIP,
         NationalOrganizationType.LABEX,
         NationalOrganizationType.EUR,
-        NationalOrganizationType.UR,
     },
     GenericOrganizationType.DOCTORAL_SCHOOL: {
         NationalOrganizationType.ED,

--- a/app/models/organization_types.py
+++ b/app/models/organization_types.py
@@ -29,6 +29,7 @@ class NationalOrganizationType(str, Enum):
     GIS = "GIS"
     GIP = "GIP"
     LABEX = "LABEX"
+    EUR = "EUR"
     TEAM = "TEAM"
     THEME = "THEME"
 
@@ -69,6 +70,7 @@ ALLOWED_NATIONAL_TYPES_BY_GENERIC_TYPE: dict = {
         NationalOrganizationType.GIS,
         NationalOrganizationType.GIP,
         NationalOrganizationType.LABEX,
+        NationalOrganizationType.EUR,
         NationalOrganizationType.UR,
     },
     GenericOrganizationType.DOCTORAL_SCHOOL: {

--- a/tests/test_models/test_organization_unit.py
+++ b/tests/test_models/test_organization_unit.py
@@ -91,7 +91,7 @@ def test_doctoral_school_rejects_non_ed_national_type(doctoral_school_a_json_dat
         nonUnitAdapter.validate_python(doctoral_school_a_json_data)
 
 
-@pytest.mark.parametrize("national_type", ["GIS", "GIP", "LABEX", "UR"])
+@pytest.mark.parametrize("national_type", ["GIS", "GIP", "LABEX", "EUR", "UR"])
 def test_institution_subdivision_accepts_research_group_national_types(national_type):
     """Institution subdivision events as sent by the directory bridge (GRALE-like)."""
     data = {

--- a/tests/test_models/test_organization_unit.py
+++ b/tests/test_models/test_organization_unit.py
@@ -91,6 +91,43 @@ def test_doctoral_school_rejects_non_ed_national_type(doctoral_school_a_json_dat
         nonUnitAdapter.validate_python(doctoral_school_a_json_data)
 
 
+@pytest.mark.parametrize("national_type", ["GIS", "GIP", "LABEX", "UR"])
+def test_institution_subdivision_accepts_research_group_national_types(national_type):
+    """Institution subdivision events as sent by the directory bridge (GRALE-like)."""
+    data = {
+        "type": national_type,
+        "contacts": [
+            {
+                "type": "postal_address",
+                "value": {
+                    "city": "PARIS CEDEX 04",
+                    "street": "Centre Malher, 9 RUE MALHER",
+                    "country": "France",
+                    "zip_code": "75181",
+                },
+                "format": "structured_physical_address",
+            }
+        ],
+        "identifiers": [{"type": "local", "value": "DS63"}],
+        "long_labels": [{"value": "GRALE", "language": "fr"}],
+        "descriptions": [
+            {
+                "value": "GRALE : Groupement de recherche sur "
+                         "l'administration locale en Europe",
+                "language": "fr",
+            }
+        ],
+        "generic_type": "institution_subdivision",
+        "main_mission": "research",
+        "short_labels": [{"value": "GRALE", "language": "fr"}],
+        "relationships": [{"type": "part_of", "target": "local-UP1"}],
+    }
+    org = nonUnitAdapter.validate_python(data)
+    assert isinstance(org, InstitutionSubdivision)
+    assert org.national_type == NationalOrganizationType(national_type)
+    assert org.parents[0].target == "local-UP1"
+
+
 def test_create_research_unit_from_json(research_unit_center_json_data):
     org = unitAdapter.validate_python(research_unit_center_json_data)
     assert isinstance(org, ResearchUnit)

--- a/tests/test_models/test_organization_unit.py
+++ b/tests/test_models/test_organization_unit.py
@@ -91,7 +91,7 @@ def test_doctoral_school_rejects_non_ed_national_type(doctoral_school_a_json_dat
         nonUnitAdapter.validate_python(doctoral_school_a_json_data)
 
 
-@pytest.mark.parametrize("national_type", ["GIS", "GIP", "LABEX", "EUR", "UR"])
+@pytest.mark.parametrize("national_type", ["GIS", "GIP", "LABEX", "EUR"])
 def test_institution_subdivision_accepts_research_group_national_types(national_type):
     """Institution subdivision events as sent by the directory bridge (GRALE-like)."""
     data = {
@@ -126,6 +126,18 @@ def test_institution_subdivision_accepts_research_group_national_types(national_
     assert isinstance(org, InstitutionSubdivision)
     assert org.national_type == NationalOrganizationType(national_type)
     assert org.parents[0].target == "local-UP1"
+
+
+def test_institution_subdivision_rejects_unit_national_types():
+    """UR is a research unit national type, not an institution subdivision one."""
+    data = {
+        "type": "UR",
+        "identifiers": [{"type": "local", "value": "DS63"}],
+        "long_labels": [{"value": "GRALE", "language": "fr"}],
+        "generic_type": "institution_subdivision",
+    }
+    with pytest.raises(ValidationError):
+        nonUnitAdapter.validate_python(data)
 
 
 def test_create_research_unit_from_json(research_unit_center_json_data):


### PR DESCRIPTION
Directory events for research groupings and graduate schools attached to institutions (e.g. GRALE/DS63, DIREVAL-PIPV-HED/DGICA_5) carry `generic_type: institution_subdivision` with national types the model rejected:

- `GIS`, `GIP`, `LABEX`, `EUR` added to `NationalOrganizationType` and allowed for `institution_subdivision`
- `UR` remains unit-only (negative test added)
- parametrized model test based on the exact rejected producer payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)