### PR TITLE
fix: resolve employment institutions by identifier before registry fallback

### DIFF
--- a/app/graph/neo4j/queries/institution_uid_by_identifier.cypher
+++ b/app/graph/neo4j/queries/institution_uid_by_identifier.cypher
@@ -1,0 +1,4 @@
+MATCH (i:Institution)-[:HAS_IDENTIFIER]->(:AgentIdentifier {type: $identifier_type, value: $identifier_value})
+RETURN i.uid AS uid
+ORDER BY coalesce(i.external, false), i.uid
+LIMIT 1

--- a/app/services/organizations/institution_service.py
+++ b/app/services/organizations/institution_service.py
@@ -2,6 +2,7 @@ from app.config import get_app_settings
 from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
 from app.graph.neo4j.neo4j_connexion import Neo4jConnexion
 from app.graph.neo4j.utils import load_query
+from app.models.identifier_types import OrganizationIdentifierType
 from app.models.organization_unit import Institution, OrganizationBase
 from app.services.identifiers.identifier_service import AgentIdentifierService
 from app.services.organizations.institution_registry_service import InstitutionRegistryService
@@ -25,6 +26,34 @@ class InstitutionService:
                     result = await tx.run(
                         load_query("institution_uid_by_uid"),
                         uid=entity_uid,
+                    )
+                    record = await result.single()
+                    return record["uid"] if record else None
+
+    async def resolve_institution_uid(self, entity_uid: str) -> str | None:
+        """
+        Resolve an entity uid to the uid of an existing Institution node.
+        First tries an exact uid match, then parses the uid as an identifier
+        "<type>-<value>" (e.g. "uai-12345") and matches it against the
+        HAS_IDENTIFIER edges of Institution nodes, preferring internal ones.
+        Returns None if nothing matches.
+        """
+        existing_uid = await self.institution_uid(entity_uid)
+        if existing_uid is not None:
+            return existing_uid
+        separator = AgentIdentifierService.IDENTIFIER_SEPARATOR
+        if separator not in entity_uid:
+            return None
+        identifier_type, identifier_value = entity_uid.split(separator, 1)
+        if OrganizationIdentifierType.from_str(identifier_type) is None:
+            return None
+        async with Neo4jConnexion().get_driver() as driver:
+            async with driver.session() as session:
+                async with await session.begin_transaction() as tx:
+                    result = await tx.run(
+                        load_query("institution_uid_by_identifier"),
+                        identifier_type=identifier_type,
+                        identifier_value=identifier_value,
                     )
                     record = await result.single()
                     return record["uid"] if record else None

--- a/app/services/people/people_service.py
+++ b/app/services/people/people_service.py
@@ -118,17 +118,26 @@ class PeopleService:
         institution_service = InstitutionService()
         valid_employments = []
         for employment in employments:
-            existing_uid = await institution_service.institution_uid(employment.entity_uid)
-            if existing_uid is None:
-                logger.warning(
-                    f"Institution with uid {employment.entity_uid!r} not found, "
-                    f"fetching from registry"
-                )
-                try:
-                    await institution_service.create_institution(employment.entity_uid)
-                except ValueError as e:
-                    logger.error(f"Error creating institution: {e}")
-                    continue
+            resolved_uid = await institution_service.resolve_institution_uid(
+                employment.entity_uid)
+            if resolved_uid is not None:
+                if resolved_uid != employment.entity_uid:
+                    logger.info(
+                        f"Employment institution {employment.entity_uid!r} resolved "
+                        f"to existing institution {resolved_uid!r}"
+                    )
+                    employment.entity_uid = resolved_uid
+                valid_employments.append(employment)
+                continue
+            logger.warning(
+                f"Institution with uid {employment.entity_uid!r} not found, "
+                f"fetching from registry"
+            )
+            try:
+                await institution_service.create_institution(employment.entity_uid)
+            except ValueError as e:
+                logger.error(f"Error creating institution: {e}")
+                continue
             valid_employments.append(employment)
         return valid_employments
 

--- a/tests/test_services/test_people_service.py
+++ b/tests/test_services/test_people_service.py
@@ -7,6 +7,7 @@ from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
 from app.models.identifier_types import OrganizationIdentifierType, PersonIdentifierType
 from app.models.organization_unit import OrganizationBase
 from app.models.people import Person
+from app.services.organizations.institution_service import InstitutionService
 from app.services.people.people_service import PeopleService
 
 
@@ -673,3 +674,26 @@ async def test_remove_identifier_wrong_value(
     assert orcid_identifier is not None
     assert orcid_identifier.value == "0000-0001-2345-6789"
 
+
+
+async def test_create_person_employment_resolved_by_identifier(
+        person_a_json_data: dict,
+        persisted_institution_a_pydantic_model: OrganizationBase,
+) -> None:
+    """
+    Given a persisted institution with a local uid and a uai identifier
+    When a person is created with an employment referencing the institution by uai
+    Then the employment is attached to the existing institution
+    and no duplicate institution is created from the registry
+    """
+    person_data = dict(person_a_json_data)
+    person_data["memberships"] = []
+    person_data["employments"] = [{"entity_uid": "uai-UAI001"}]
+    person = Person(**person_data)
+    service = PeopleService()
+    await service.create_person(person)
+    fetched_person = await service.get_person(person.uid)
+    assert len(fetched_person.employments) == 1
+    assert (fetched_person.employments[0].entity_uid
+            == persisted_institution_a_pydantic_model.uid)
+    assert await InstitutionService().institution_uid("uai-UAI001") is None


### PR DESCRIPTION
## Problem

Employments from the LDAP import reference institutions by national identifiers (e.g. `uai-12345`), while internally managed structures have `local-*` uids. The employment path resolved institutions strictly by node uid, so a `uai-12345` employment never matched the existing local structure carrying the `(uai, 12345)` identifier — instead a duplicate external Institution node was fetched from the registry and `EMPLOYED_AT` attached to it.

## Fix

- New query `institution_uid_by_identifier.cypher`: matches `(:Institution)-[:HAS_IDENTIFIER]->(:AgentIdentifier {type, value})`, preferring internal nodes (`ORDER BY coalesce(i.external, false)`).
- `InstitutionService.resolve_institution_uid(entity_uid)`: exact uid match first, then parses `<type>-<value>` and matches by identifier; returns `None` if the type is not a valid `OrganizationIdentifierType` or nothing matches.
- `PeopleService._update_employers_institutions`: substitutes the resolved uid into `employment.entity_uid` so `EMPLOYED_AT` binds to the existing node; the external-registry fallback only fires when neither uid nor identifier matches. Covers all entry points (AMQP created/updated/unchanged, CLI).

Substitution is stable across re-imports: the next message resolves to the same local uid, so `_employments_are_identical` sees no spurious change.

## Tests

- New `test_create_person_employment_resolved_by_identifier`: employment with `uai-UAI001` attaches to existing `local-EXAMPLE-UNIV-001` institution, no duplicate node created.
- Full suite: 390 passed. Pylint: 10.00/10 (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)