### PR TITLE
fix: prevent bare Person resurrection by contribution creation

### DIFF
--- a/app/graph/neo4j/queries/create_contribution_to_document.cypher
+++ b/app/graph/neo4j/queries/create_contribution_to_document.cypher
@@ -1,5 +1,5 @@
-MERGE (doc:Document {uid: $document_uid})
-MERGE (person:Person {uid: $person_uid})
+MATCH (doc:Document {uid: $document_uid})
+MATCH (person:Person {uid: $person_uid})
 MERGE (doc)-[:HAS_CONTRIBUTION]->(contribution:Contribution)<-[:HAS_CONTRIBUTION]-(person)
 ON CREATE SET contribution.roles = $roles, contribution.rank = $rank
 ON MATCH SET contribution.roles = $roles, contribution.rank = $rank

--- a/app/graph/neo4j/queries/merge_external_people.cypher
+++ b/app/graph/neo4j/queries/merge_external_people.cypher
@@ -1,27 +1,32 @@
 MATCH (person_to_keep:Person {uid: $person_to_keep_uid})
 MATCH (person_to_merge:Person {uid: $person_to_merge_uid})
 
-// Transfer HAS_CONTRIBUTION relationships
-OPTIONAL MATCH (person_to_merge)-[rel:HAS_CONTRIBUTION]->(contribution:Contribution)<-[:HAS_CONTRIBUTION]-(d:Document)
-WHERE NOT EXISTS {
-    MATCH (person_to_keep)-[:HAS_CONTRIBUTION]->(:Contribution)<-[:HAS_CONTRIBUTION]-(d)
+// Delete genuine duplicates: person_to_merge's contributions on documents
+// where person_to_keep already has a contribution
+CALL {
+    WITH person_to_keep, person_to_merge
+    MATCH (person_to_merge)-[:HAS_CONTRIBUTION]->(duplicate:Contribution)
+          <-[:HAS_CONTRIBUTION]-(doc:Document)
+    WHERE EXISTS {
+        MATCH (person_to_keep)-[:HAS_CONTRIBUTION]->(:Contribution)<-[:HAS_CONTRIBUTION]-(doc)
+    }
+    DETACH DELETE duplicate
 }
-WITH person_to_keep, person_to_merge, contribution
-WHERE contribution IS NOT NULL
-MERGE (person_to_keep)-[:HAS_CONTRIBUTION]->(contribution)
 
-WITH person_to_keep, person_to_merge
-  MATCH (person_to_merge)-[rel:HAS_CONTRIBUTION]->(contribution:Contribution)
-DETACH DELETE contribution
-
-WITH person_to_keep, person_to_merge
-OPTIONAL MATCH (person_to_merge)-[rel:RECORDED_BY]->(source_person:SourcePerson)
-WHERE NOT EXISTS {
-    MATCH (person_to_keep)-[:RECORDED_BY]->(source_person)
+// Transfer the remaining contributions by re-pointing the edge onto person_to_keep
+CALL {
+    WITH person_to_keep, person_to_merge
+    MATCH (person_to_merge)-[rel:HAS_CONTRIBUTION]->(contribution:Contribution)
+    MERGE (person_to_keep)-[:HAS_CONTRIBUTION]->(contribution)
+    DELETE rel
 }
-WITH person_to_keep, person_to_merge, source_person
-WHERE source_person IS NOT NULL
-MERGE (person_to_keep)-[:RECORDED_BY]->(source_person)
 
-// Delete person_to_merge and its relationships
+// Transfer RECORDED_BY relationships
+CALL {
+    WITH person_to_keep, person_to_merge
+    MATCH (person_to_merge)-[:RECORDED_BY]->(source_person:SourcePerson)
+    MERGE (person_to_keep)-[:RECORDED_BY]->(source_person)
+}
+
+// Delete person_to_merge and its remaining relationships
 DETACH DELETE person_to_merge

--- a/app/services/source_contributors/source_contributor_mapping_service.py
+++ b/app/services/source_contributors/source_contributor_mapping_service.py
@@ -92,14 +92,24 @@ class SourceContributorMappingService:
             source_people_cluster = [person for person in self.source_people if
                                      person.uid in source_people_cluster_uids]
             yet_processed_source_person_uids.update(source_people_cluster_uids)
-            person_uid = (
-                    await self._match_by_identifiers(source_people_cluster)
-                    or await self._match_by_name(source_people_cluster)
-                    or await self._match_with_external_person(source_people_cluster)
-            )
+            person_uid = await self._resolve_cluster(source_people_cluster)
             if person_uid is not None:
                 linked_people[person_uid] = source_people_cluster
         return linked_people
+
+    async def _resolve_cluster(self, source_people_cluster: List[SourcePerson]) -> str | None:
+        """
+        Resolve a cluster of source people to a real person uid, by identifiers,
+        by name, or by creating/finding an external person.
+
+        :param source_people_cluster: List of SourcePerson objects.
+        :return: The UID of the resolved person, or None if no person could be resolved.
+        """
+        return (
+                await self._match_by_identifiers(source_people_cluster)
+                or await self._match_by_name(source_people_cluster)
+                or await self._match_with_external_person(source_people_cluster)
+        )
 
     async def _match_by_name(self, source_people_cluster: List[SourcePerson]) -> str | None:
         """
@@ -206,14 +216,30 @@ class SourceContributorMappingService:
         :param source_people_cluster: List of SourcePerson objects
         :return: The UID of the merged person
         """
-        person_to_keep_uid = existing_external_people_uids.pop()
-        for person_to_merge_uid in existing_external_people_uids:
+        ordered_uids = sorted(existing_external_people_uids, key=self._survivor_election_key)
+        person_to_keep_uid = ordered_uids[0]
+        for person_to_merge_uid in ordered_uids[1:]:
             await self.person_dao.merge_people(person_to_keep_uid, person_to_merge_uid)
         # Link the source people to the merged person
         await self.source_person_dao.link_to_person([source_person.uid for source_person in
                                                      source_people_cluster],
                                                     person_to_keep_uid)
         return person_to_keep_uid
+
+    def _survivor_election_key(self, person_uid: str) -> tuple:
+        """
+        Sort key for electing the surviving person of an external-people merge:
+        harvester priority of the uid's source prefix (same order as used by
+        _build_external_person), tie-broken by uid, so repeated merges converge
+        on the same survivor.
+
+        :param person_uid: candidate person uid (e.g. "hal-170517")
+        :return: sort key tuple
+        """
+        sources = self._get_harvesting_sources()
+        prefix = person_uid.split("-", 1)[0]
+        priority = sources.index(prefix) if prefix in sources else len(sources)
+        return priority, person_uid
 
     async def _update_contributions(self, linked_people):
         document_dao = self._get_document_dao()
@@ -233,6 +259,23 @@ class SourceContributorMappingService:
                 person_uid=person_uid,
                 roles=[role.value for role in roles]
             )
+            if contribution_id is None:
+                # the person may have been deleted by a concurrent external-people merge
+                # since the linking phase: re-resolve the cluster once and retry
+                person_uid = await self._resolve_cluster(source_people_cluster)
+                if person_uid is not None:
+                    contribution_id = await document_dao.create_contribution(
+                        document_uid=self.document_uid,
+                        person_uid=person_uid,
+                        roles=[role.value for role in roles]
+                    )
+            if contribution_id is None:
+                logger.error(
+                    "Could not create contribution for document {}: person {} "
+                    "(source people {}) does not exist",
+                    self.document_uid, person_uid,
+                    [source_person.uid for source_person in source_people_cluster])
+                continue
             # get source organizations for the source people cluster
             source_organisations = self._get_organisations_for_person(
                 source_people_cluster,
@@ -253,8 +296,7 @@ class SourceContributorMappingService:
                 targets=elected_target_uids,
             )
 
-            if contribution_id is not None:
-                current_contribution_ids.add(contribution_id)
+            current_contribution_ids.add(contribution_id)
         # Delete contributions that are not in the current set
         await document_dao.delete_contributions_not_in(
             document_uid=self.document_uid,

--- a/specs/contributor-without-name-creates-missing-publication-in-sovisu#412/prompt.md
+++ b/specs/contributor-without-name-creates-missing-publication-in-sovisu#412/prompt.md
@@ -1,0 +1,171 @@
+# Contributor without name creates missing publication in SoVisu+
+
+Issue: https://github.com/CRISalid-esr/crisalid-ikg/issues/412
+
+## Context
+
+Some documents carry a `Contribution` whose `Person` node is an empty shell: no
+`display_name`, no `external` flag, no `HAS_NAME` → `PersonName` relations, no
+`RECORDED_BY` → `SourcePerson` relations — nothing but a `uid` (e.g. `hal-170517`).
+SoVisu+ cannot render such a contributor, so the whole publication is dropped on its side.
+Running `documents recompute_metadata` on the affected document makes the problem
+disappear, and the bug could not be reproduced deterministically: it only shows up during
+the initial publication load.
+
+### Root cause (confirmed on the testing graph)
+
+The empty node is the footprint of a **race between two concurrent
+`SourceContributorMappingService.update_contributions()` runs on documents that share
+external co-authors**, combined with a silent-resurrection `MERGE`:
+
+1. `update_contributions()` runs in two non-transactional phases:
+   `_link_source_people_to_people()` resolves person uids into an in-memory dict, then
+   `_update_contributions()` writes contributions from that dict. There is no per-document
+   or per-person serialization: AMQP processors run with ~10 parallel workers and every
+   `source_record_created` cascades (via `EquivalenceService` →
+   `document_sources_changed` / `document_created_from_sources` → `DocumentService`)
+   into a fresh mapping run.
+2. During first load, the same external co-author is discovered concurrently from several
+   sources/documents, so duplicate external `Person` nodes get created. When a later run's
+   cluster resolves to two or more existing external persons,
+   `_merge_external_people()` merges them: `merge_external_people.cypher` ends with
+   `DETACH DELETE person_to_merge`.
+3. If another worker resolved the soon-to-be-deleted person in its phase 1, its phase 2
+   then calls `DocumentDAO.create_contribution`, whose query
+   (`create_contribution_to_document.cypher`) begins with:
+
+   ```cypher
+   MERGE (person:Person {uid: $person_uid})
+   ```
+
+   The `MERGE` silently **recreates the deleted person as a bare node with only a `uid`**
+   and attaches the contribution to it.
+4. The same stale run finishes with `delete_contributions_not_in`, which also removes the
+   contribution that the merge-winning (complete) person may have had on the document —
+   so the named person ends up absent from the document entirely.
+
+Verified in the testing graph: `Person {uid: 'hal-170517'}` has `uid` as its only property
+(impossible via `create_person.cypher`, which always sets `display_name` and `external`);
+the `SourcePerson hal-170517` ("Valérie Gouet-Brunet") is `RECORDED_BY` the surviving
+complete person `scanr-idref174365020`, which holds the merged source-person cluster
+(hal / openalex / scanr / sudoc) and has contributions on 11 other documents but not on the
+affected ones. 98 bare persons exist in that graph, 68 of which still hold contributions,
+affecting 66 documents.
+
+A recompute heals a document because it is a single serialized run: the source people are
+`RECORDED_BY` the surviving person, `get_person_uid_by_source_person_uid` resolves to it,
+the contribution is recreated on the named person, and `delete_contributions_not_in`
+removes the bare node's contribution.
+
+### Adjacent defects found during the analysis (in scope — do not lose them)
+
+**(a) `merge_external_people.cypher` deletes the contributions it just transferred.**
+The query first `MERGE`s `(person_to_keep)-[:HAS_CONTRIBUTION]->(contribution)` for
+contributions on documents where the keep-person has none, then:
+
+```cypher
+MATCH (person_to_merge)-[rel:HAS_CONTRIBUTION]->(contribution:Contribution)
+DETACH DELETE contribution
+```
+
+The transfer never removed the `person_to_merge` edge, so this second `MATCH` re-matches
+the transferred contributions too and deletes them all. The merged-into person silently
+loses those contributions until the next recompute of each document.
+
+**(b) Non-deterministic merge survivor.** `_merge_external_people()` picks the person to
+keep with `existing_external_people_uids.pop()` on a `set` — arbitrary ordering. The merge
+direction varies between runs, which widens the window in which two concurrent runs
+disagree about which uid is "the" person, and makes incidents impossible to reproduce.
+
+## Goal
+
+1. A contribution must never be attached to a `Person` node that does not exist: the
+   silent-resurrection path must be removed and replaced by a loud failure plus recovery.
+2. Merging external people must preserve their contributions (modulo genuine duplicates on
+   the same document).
+3. The merge survivor election must be deterministic.
+
+Repairing already-polluted graphs is out of scope: recomputing the affected documents
+(those with a contribution from a `Person` with no `display_name` and no `HAS_NAME`
+relation) through the existing recompute path heals them, and the leftover bare nodes can
+be cleaned up manually.
+
+Full serialization of contribution mapping (global or per-cluster locking) is **out of
+scope**: the cross-document nature of the race makes a per-document lock insufficient, and
+a global lock would throttle first-load throughput. The fail-loud + retry design below
+makes the race harmless instead.
+
+## Design
+
+### A. `create_contribution_to_document.cypher`: `MERGE` → `MATCH` on Person
+
+```cypher
+MATCH (doc:Document {uid: $document_uid})
+MATCH (person:Person {uid: $person_uid})
+MERGE (doc)-[:HAS_CONTRIBUTION]->(contribution:Contribution)<-[:HAS_CONTRIBUTION]-(person)
+...
+```
+
+The `Document` `MERGE` is downgraded to `MATCH` as well: the document always exists when
+contributions are reconciled (both callers operate on a persisted document), and a bare
+`Document` shell would be the same class of corruption.
+
+`DocumentDAO.create_contribution` already returns `None` when the query yields no row —
+that becomes the "person (or document) vanished" signal. Both callers must handle it:
+
+- `ContributionUpdateService.reconcile` (app/services/contributions/) already handles
+  `None` with a `CONTRIBUTION_NOT_CREATED` warning — no change needed.
+- `SourceContributorMappingService._update_contributions` currently ignores it (it even
+  passes a possibly-`None` `contribution_id` to
+  `update_contribution_affiliation_statements`). New behaviour per linked person:
+  1. If `create_contribution` returns `None`, re-resolve the cluster once: re-run the
+     matching chain of `_link_source_people_to_people` for that single cluster
+     (`_match_by_identifiers` → `_match_by_name` → `_match_with_external_person`) and
+     retry `create_contribution` with the new uid. The concurrent merge that deleted the
+     person has, by then, re-pointed `RECORDED_BY` onto the surviving person, so the
+     retry resolves correctly.
+  2. If the retry still returns `None`, log an error with document uid + person uid +
+     source-person uids and skip the contribution (the next recompute heals it). Never
+     pass a `None` contribution id to `update_contribution_affiliation_statements`.
+
+### B. Fix `merge_external_people.cypher` (defect a)
+
+Rewrite the contribution section so that:
+
+- contributions of `person_to_merge` on documents where `person_to_keep` **already has** a
+  contribution are deleted (genuine duplicates);
+- all other contributions are transferred: create the
+  `(person_to_keep)-[:HAS_CONTRIBUTION]->(contribution)` edge **and delete the
+  `(person_to_merge)-[:HAS_CONTRIBUTION]->(contribution)` edge** instead of deleting the
+  contribution node;
+- the `RECORDED_BY` transfer and final `DETACH DELETE person_to_merge` stay as they are
+  (the final `DETACH DELETE` no longer removes contribution edges, since they were
+  re-pointed explicitly).
+
+### C. Deterministic survivor election (defect b)
+
+In `_merge_external_people()`, replace `set.pop()` with an explicit election: sort the
+candidate uids with the same harvester-priority used by `_build_external_person` (the
+`harvesting_sources` order from `publication_source_policies`, matching on the uid's
+source prefix), tie-broken lexicographically, and keep the first. Repeated merges then
+converge on the same survivor, matching the uid `_build_external_person` would mint for
+the same cluster.
+
+### Tests
+
+All tests run against the real Neo4j test instance (`APP_ENV=TEST pytest`).
+
+1. **No resurrection**: `create_contribution` with a non-existent person uid returns
+   `None` and creates neither a `Person` nor a `Contribution` node; same for a
+   non-existent document uid.
+2. **Race recovery**: build a document whose linked person is deleted after phase 1
+   (simulate by deleting the person and re-pointing `RECORDED_BY` onto a surviving person
+   between `_link_source_people_to_people` and `_update_contributions`); assert the
+   contribution lands on the surviving person and no bare node appears.
+3. **Race skip**: same setup but with no surviving person resolvable; assert the
+   contribution is skipped, an error is logged, and the graph contains no bare person.
+4. **Merge keeps contributions**: person A with contributions on documents D1, D2; person
+   B (keep) with a contribution on D1 only. After merge: B has contributions on D1 and D2,
+   the D1 duplicate is gone, no contribution node was orphaned or lost.
+5. **Deterministic election**: clusters presented in different orders always elect the
+   same survivor, and the survivor matches the harvester-priority rule.

--- a/tests/test_services/test_contribution_person_consistency.py
+++ b/tests/test_services/test_contribution_person_consistency.py
@@ -1,0 +1,266 @@
+"""
+Tests for contribution/person consistency under concurrent external-people merges
+(issue #412): a contribution must never resurrect a deleted Person as a bare node,
+and merging external people must preserve their contributions.
+"""
+from itertools import permutations
+from typing import cast
+
+from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
+from app.graph.neo4j.document_dao import DocumentDAO
+from app.graph.neo4j.neo4j_connexion import Neo4jConnexion
+from app.graph.neo4j.person_dao import PersonDAO
+from app.models.document import Document
+from app.models.people import Person
+from app.models.source_records import SourceRecord
+from app.services.source_contributors.source_contributor_mapping_service import \
+    SourceContributorMappingService
+from app.services.source_records.equivalence_service import EquivalenceService
+from app.signals import source_record_created, source_record_updated, \
+    document_sources_changed, document_created_from_sources
+
+AUTHOR_ROLE = "http://id.loc.gov/vocabulary/relators/aut"
+
+
+def _document_dao() -> DocumentDAO:
+    factory = AbstractDAOFactory().get_dao_factory("neo4j")
+    return cast(DocumentDAO, factory.get_dao(Document))
+
+
+def _person_dao() -> PersonDAO:
+    factory = AbstractDAOFactory().get_dao_factory("neo4j")
+    return cast(PersonDAO, factory.get_dao(Person))
+
+
+async def _run_count_query(query: str, **params) -> int:
+    async with Neo4jConnexion().get_driver() as driver:
+        async with driver.session() as session:
+            result = await session.run(query, **params)
+            record = await result.single()
+            return record["count"]
+
+
+async def _count_persons_by_uid(person_uid: str) -> int:
+    return await _run_count_query(
+        "MATCH (p:Person {uid: $uid}) RETURN count(p) AS count", uid=person_uid)
+
+
+async def _count_bare_persons() -> int:
+    """Persons with no display_name and no HAS_NAME relation (resurrection footprint)."""
+    return await _run_count_query(
+        "MATCH (p:Person) WHERE p.display_name IS NULL AND NOT (p)-[:HAS_NAME]->() "
+        "RETURN count(p) AS count")
+
+
+async def _count_document_contributions(document_uid: str) -> int:
+    return await _run_count_query(
+        "MATCH (:Document {uid: $uid})-[:HAS_CONTRIBUTION]->(c:Contribution) "
+        "RETURN count(c) AS count", uid=document_uid)
+
+
+async def _count_contributions_between(document_uid: str, person_uid: str) -> int:
+    return await _run_count_query(
+        "MATCH (:Document {uid: $document_uid})-[:HAS_CONTRIBUTION]->(c:Contribution)"
+        "<-[:HAS_CONTRIBUTION]-(:Person {uid: $person_uid}) RETURN count(c) AS count",
+        document_uid=document_uid, person_uid=person_uid)
+
+
+async def _count_orphan_contributions() -> int:
+    return await _run_count_query(
+        "MATCH (c:Contribution) WHERE NOT (c)<-[:HAS_CONTRIBUTION]-(:Person) "
+        "RETURN count(c) AS count")
+
+
+async def _create_document_for_source_record(source_record: SourceRecord) -> Document:
+    """Create the document of a source record through the equivalence service."""
+    with source_record_updated.muted(), source_record_created.muted(), \
+            document_sources_changed.muted(), document_created_from_sources.muted():
+        await EquivalenceService().update_source_record(None, source_record.uid)
+    document = await _document_dao().get_document_by_source_record_uid(source_record.uid)
+    assert document is not None
+    return document
+
+
+async def test_create_contribution_with_missing_person_creates_nothing(
+        persisted_person_a_pydantic_model: Person,
+        hal_article_a_source_record_persisted_model: SourceRecord,
+) -> None:
+    """
+    Given an existing document
+    When a contribution is created for a person uid that does not exist
+    Then no contribution is created and no bare Person node appears
+    """
+    document = await _create_document_for_source_record(
+        hal_article_a_source_record_persisted_model)
+    # depending on registered signal receivers, the document may already carry
+    # contributions at this point: assert on the delta, not on an absolute count
+    contributions_before = await _count_document_contributions(document.uid)
+    contribution_id = await _document_dao().create_contribution(
+        document_uid=document.uid,
+        person_uid="ghost-person",
+        roles=[AUTHOR_ROLE])
+    assert contribution_id is None
+    assert await _count_persons_by_uid("ghost-person") == 0
+    assert await _count_document_contributions(document.uid) == contributions_before
+    assert await _count_bare_persons() == 0
+
+
+async def test_create_contribution_with_missing_document_creates_nothing(
+        persisted_person_a_pydantic_model: Person,
+) -> None:
+    """
+    Given an existing person
+    When a contribution is created for a document uid that does not exist
+    Then no contribution and no bare Document node are created
+    """
+    contribution_id = await _document_dao().create_contribution(
+        document_uid="ghost-document",
+        person_uid=persisted_person_a_pydantic_model.uid,
+        roles=[AUTHOR_ROLE])
+    assert contribution_id is None
+    assert await _run_count_query(
+        "MATCH (d:Document {uid: 'ghost-document'}) RETURN count(d) AS count") == 0
+
+
+async def test_contribution_mapping_recovers_from_concurrent_merge(
+        persisted_person_a_pydantic_model: Person,  # pylint: disable=unused-argument
+        hal_article_a_source_record_persisted_model: SourceRecord,
+) -> None:
+    """
+    Given a document whose contributor clusters have been linked to people
+    When one linked external person is deleted by a concurrent merge before
+    the contributions are written
+    Then the contribution is re-resolved onto the surviving person and no bare
+    Person node is created
+    """
+    source_record = hal_article_a_source_record_persisted_model
+    document = await _create_document_for_source_record(source_record)
+    service = SourceContributorMappingService(
+        source_records=[source_record], document_uid=document.uid)
+    # pylint: disable=protected-access
+    linked_people = await service._link_source_people_to_people()
+    stale_person_uid = "hal-863912"
+    assert stale_person_uid in linked_people
+    # Simulate a concurrent run merging the linked person into a survivor:
+    # the person node is deleted and its RECORDED_BY relations are re-pointed
+    surviving_person = Person(
+        uid="scanr-idref00000001", display_name="Jérôme Février", external=True)
+    await _person_dao().create(surviving_person)
+    await _person_dao().merge_people(surviving_person.uid, stale_person_uid)
+    assert await _count_persons_by_uid(stale_person_uid) == 0
+
+    await service._update_contributions(linked_people)
+
+    # the stale person was not resurrected
+    assert await _count_persons_by_uid(stale_person_uid) == 0
+    assert await _count_bare_persons() == 0
+    # the contribution landed on the surviving person
+    assert await _count_contributions_between(document.uid, surviving_person.uid) == 1
+    # every contributor of the record got a contribution
+    assert await _count_document_contributions(document.uid) == len(linked_people)
+
+
+async def test_contribution_mapping_skips_unresolvable_person(
+        persisted_person_a_pydantic_model: Person,  # pylint: disable=unused-argument
+        hal_article_a_source_record_persisted_model: SourceRecord,
+) -> None:
+    """
+    Given a linked person that no longer exists and cannot be re-resolved
+    When the contributions are written
+    Then the contribution is skipped without error and no bare Person node is created
+    """
+    source_record = hal_article_a_source_record_persisted_model
+    document = await _create_document_for_source_record(source_record)
+    service = SourceContributorMappingService(
+        source_records=[source_record], document_uid=document.uid)
+
+    async def _unresolvable(_cluster):
+        return None
+
+    # pylint: disable=protected-access
+    service._resolve_cluster = _unresolvable
+    ghost_cluster = [source_record.contributions[0].contributor]
+    await service._update_contributions({"ghost-person": ghost_cluster})
+
+    assert await _count_persons_by_uid("ghost-person") == 0
+    assert await _count_bare_persons() == 0
+    assert await _count_document_contributions(document.uid) == 0
+
+
+async def test_merge_external_people_preserves_contributions() -> None:
+    """
+    Given person A with contributions on documents D1 and D2,
+    and person B with a contribution on D1 only
+    When A is merged into B
+    Then B holds one contribution on each document, the D1 duplicate is removed,
+    and no contribution is orphaned
+    """
+    person_dao = _person_dao()
+    document_dao = _document_dao()
+    person_a = Person(uid="hal-ext-author", display_name="Ext Author", external=True)
+    person_b = Person(uid="scanr-ext-author", display_name="Ext Author", external=True)
+    await person_dao.create(person_a)
+    await person_dao.create(person_b)
+    await document_dao.create_or_update_document(Document(uid="doc-merge-1"))
+    await document_dao.create_or_update_document(Document(uid="doc-merge-2"))
+    assert await document_dao.create_contribution(
+        "doc-merge-1", person_a.uid, roles=[AUTHOR_ROLE]) is not None
+    assert await document_dao.create_contribution(
+        "doc-merge-2", person_a.uid, roles=[AUTHOR_ROLE]) is not None
+    assert await document_dao.create_contribution(
+        "doc-merge-1", person_b.uid, roles=[AUTHOR_ROLE]) is not None
+
+    await person_dao.merge_people(person_b.uid, person_a.uid)
+
+    assert await _count_persons_by_uid(person_a.uid) == 0
+    assert await _count_contributions_between("doc-merge-1", person_b.uid) == 1
+    assert await _count_contributions_between("doc-merge-2", person_b.uid) == 1
+    assert await _count_document_contributions("doc-merge-1") == 1
+    assert await _count_document_contributions("doc-merge-2") == 1
+    assert await _count_orphan_contributions() == 0
+
+
+async def test_merge_external_people_transfers_recorded_by() -> None:
+    """
+    Given a merged person recorded by a source person
+    When the person is merged into a survivor
+    Then the RECORDED_BY relation is transferred to the survivor
+    """
+    person_dao = _person_dao()
+    person_a = Person(uid="hal-ext-recorded", display_name="Ext Recorded", external=True)
+    person_b = Person(uid="scanr-ext-recorded", display_name="Ext Recorded", external=True)
+    await person_dao.create(person_a)
+    await person_dao.create(person_b)
+    async with Neo4jConnexion().get_driver() as driver:
+        async with driver.session() as session:
+            await session.run(
+                "CREATE (sp:SourcePerson {uid: 'hal-sp-recorded'}) "
+                "WITH sp MATCH (p:Person {uid: 'hal-ext-recorded'}) "
+                "CREATE (p)-[:RECORDED_BY]->(sp)")
+
+    await person_dao.merge_people(person_b.uid, person_a.uid)
+
+    assert await _run_count_query(
+        "MATCH (:Person {uid: 'scanr-ext-recorded'})-[r:RECORDED_BY]->"
+        "(:SourcePerson {uid: 'hal-sp-recorded'}) RETURN count(r) AS count") == 1
+    assert await _count_persons_by_uid(person_a.uid) == 0
+
+
+def test_external_people_merge_survivor_election_is_deterministic() -> None:
+    """
+    Given a set of external person uids from different sources
+    When the merge survivor is elected
+    Then the election follows the harvester priority order regardless of input order,
+    with unknown prefixes last and lexicographic tie-break
+    """
+    service = SourceContributorMappingService(source_records=[], document_uid="none")
+    # pylint: disable=protected-access
+    uids = ["openalex-https://openalex.org/A5041561153", "scanr-idref174365020", "hal-170517"]
+    for permutation in permutations(uids):
+        elected = sorted(permutation, key=service._survivor_election_key)[0]
+        assert elected == "hal-170517"
+    # unknown source prefixes sort after known ones
+    assert sorted(["sudoc-http://www.idref.fr/174365020/id", "openalex-x"],
+                  key=service._survivor_election_key)[0] == "openalex-x"
+    # lexicographic tie-break within the same source
+    assert sorted(["hal-2", "hal-1"], key=service._survivor_election_key)[0] == "hal-1"


### PR DESCRIPTION
Fixes #412

Contributions could end up attached to an empty `Person` node (only a `uid`, no `display_name`, no `HAS_NAME`, no `RECORDED_BY`), which prevented the publication from being sent to SoVisu+. Root cause: a race between concurrent `update_contributions` runs on documents sharing external co-authors — `_merge_external_people` `DETACH DELETE`s a person that another run has already resolved, and the `MERGE (person:Person {uid})` in `create_contribution_to_document.cypher` silently resurrects it as a bare shell.

Changes:
- `create_contribution_to_document.cypher`: `MATCH` instead of `MERGE` on Person and Document; on a missing person the mapping service re-resolves the cluster once and retries, then skips with an error
- `merge_external_people.cypher`: transfer contributions to the surviving person instead of deleting them (only genuine same-document duplicates are removed); also fixes the case where a person with no contributions was never deleted
- deterministic survivor election for external-people merges (harvester-priority order, lexicographic tie-break)
- spec in `specs/` and integration tests

Note: already-polluted graphs still need a one-off recompute of the affected documents (those with a contribution from a bare person).

🤖 Generated with [Claude Code](https://claude.com/claude-code)