### PR TITLE
feat: default contribution role to Contributor when null

### DIFF
--- a/app/graph/neo4j/source_record_dao.py
+++ b/app/graph/neo4j/source_record_dao.py
@@ -399,7 +399,7 @@ class SourceRecordDAO(Neo4jDAO):
             query,
             source_record_uid=source_record_uid,
             contributor_uid=source_contribution.contributor.uid,
-            role=source_contribution.role.name if source_contribution.role else None,
+            role=source_contribution.role.name,
             rank=source_contribution.rank,
             affiliation_uids=[affiliation.uid for affiliation in source_contribution.affiliations]
         )
@@ -641,9 +641,10 @@ class SourceRecordDAO(Neo4jDAO):
         for contribution in contributions:
             try:
                 role = LocContributionRole.from_name(
-                    contribution["role"]) if "role" in contribution else None
+                    contribution["role"]) if "role" in contribution \
+                    else LocContributionRole.CONTRIBUTOR
             except ValueError:
-                role = None
+                role = LocContributionRole.CONTRIBUTOR
             affiliations = []
             for affiliation in contribution.get("affiliations", []):
                 source_organization = SourceOrganization(

--- a/app/models/source_contributions.py
+++ b/app/models/source_contributions.py
@@ -14,7 +14,7 @@ class SourceContribution(BaseModel):
     Source Contribution model
     """
     rank: Optional[int] = None
-    role: Optional[LocContributionRole] = None
+    role: LocContributionRole = LocContributionRole.CONTRIBUTOR
     contributor: SourcePerson
     affiliations: List[SourceOrganization] = []
 
@@ -23,17 +23,18 @@ class SourceContribution(BaseModel):
     def validate_role(cls, value):
         """
         Convert a role URI to the corresponding LocContributionRole Enum entry.
+        Absent or unrecognized roles default to the generic Contributor role.
         """
         if isinstance(value, LocContributionRole):
             return value
         if value is None or not isinstance(value, str):
-            return None
+            return LocContributionRole.CONTRIBUTOR
         value = cls.url_to_uri(value)
         try:
             return LocContributionRole(value)
         except ValueError:
             logger.error(f"Invalid contribution role: {value}")
-            return None
+            return LocContributionRole.CONTRIBUTOR
 
     @staticmethod
     def url_to_uri(url: str) -> str:

--- a/app/services/contributions/contribution_update_service.py
+++ b/app/services/contributions/contribution_update_service.py
@@ -13,6 +13,7 @@ from app.models.change_report import ChangeApplicationReport
 from app.models.document import Document
 from app.models.harvesting_sources import HarvestingSource
 from app.models.identifier_types import OrganizationIdentifierType, PersonIdentifierType
+from app.models.loc_contribution_role import LocContributionRole
 from app.models.people import Person
 from app.models.source_organization_identifiers import SourceOrganizationIdentifier
 from app.models.source_organizations import SourceOrganization
@@ -77,7 +78,8 @@ class ContributionUpdateService:
                         identifiers=self._incoming_identifiers(person),
                     )
                 continue
-            roles = contribution.get("roles") or []
+            # a contribution without roles defaults to the generic Contributor role
+            roles = contribution.get("roles") or [LocContributionRole.CONTRIBUTOR.value]
             rank = contribution.get("rank")
             contribution_id = await document_dao.create_contribution(
                 document_uid=document_uid,

--- a/app/services/source_contributors/source_contributor_mapping_service.py
+++ b/app/services/source_contributors/source_contributor_mapping_service.py
@@ -386,9 +386,13 @@ class SourceContributorMappingService:
         for person in sorted_people:
             for contribution in contributions:
                 if (contribution.contributor.uid == person.uid
-                        and contribution.role is not None
                         and contribution.role not in roles):
                     roles.append(contribution.role)
+
+        # The generic Contributor role (default for sources providing no role) is
+        # subsumed by any specific role: keep it only when it is the sole role
+        if len(roles) > 1:
+            roles = [role for role in roles if role != LocContributionRole.CONTRIBUTOR]
 
         return roles
 

--- a/specs/set-default-sourcecontribution-role-to-contributor-when-null#414/prompt.md
+++ b/specs/set-default-sourcecontribution-role-to-contributor-when-null#414/prompt.md
@@ -1,0 +1,119 @@
+# Set default SourceContribution role to "Contributor" when null
+
+Issue: https://github.com/CRISalid-esr/crisalid-ikg/issues/414
+
+## Context
+
+Downstream consumers (SoVisu+) are notified about source contributions carrying a null
+role, and the graph contains `Contribution` nodes with an empty `roles` list, which
+propagate as `"roles": []` in outbound document events.
+
+### How roles flow today
+
+1. **Inbound**: `AMQPReferenceMessageProcessor` builds `SourceRecord(**reference_data)`.
+   `SourceContribution.role` is `Optional[LocContributionRole]`; the `validate_role`
+   field validator returns `None` in two distinct cases:
+   - the payload carries no role (or a non-string value);
+   - the role URL does not map to a LoC relator (logs `Invalid contribution role`).
+2. **Source layer write**: `SourceRecordDAO._create_contribution_transaction` passes
+   `role=source_contribution.role.name if source_contribution.role else None` to
+   `create_source_contribution.cypher` (`SET sc.role = $role`). A null parameter leaves
+   the `SourceContribution` node without a `role` property (stores the enum **name**,
+   e.g. `"AUTHOR"`).
+3. **Hydration**: `SourceRecordDAO._hydrate_contributions` maps a missing or
+   unrecognized `role` property back to `role=None`.
+4. **Document merge**: `SourceContributorMappingService._get_roles_by_harvester_order`
+   skips `None` roles, so a person whose source contributions all lack a role gets
+   `Contribution.roles = []` (stores the enum **values**, i.e. LoC URIs).
+5. **Second write path**: `ContributionUpdateService.reconcile` (sovisuplus
+   contribution-update messages) does `roles = contribution.get("roles") or []` and
+   writes them verbatim — an empty or missing list also yields `Contribution.roles = []`.
+6. **Outbound**: `AMQPDocumentEventMessageFactory` serializes
+   `contribution.model_dump()`, so the empty list reaches subscribers.
+
+### Neo4j database findings (2026-07-24, publications only partially loaded)
+
+- 210,338 `SourceContribution` nodes; **624 have no `role`** — all of them harvested by
+  **idref** (Sudoc records).
+- 130,000 `Contribution` nodes; **554 have `roles = []`** (none have `roles IS NULL`).
+- For every one of those 554 contributions, the roles collected over the person's source
+  contributions on the document's source records reduce to `[]` (all null) — the
+  propagation chain above is confirmed as the only cause. All affected documents include
+  an idref source record.
+
+## Goal
+
+A contribution role is never null/empty anywhere in the pipeline: when a source does not
+provide a usable role, the contribution defaults to the generic LoC **Contributor** role
+(`http://id.loc.gov/vocabulary/relators/ctb` / `LocContributionRole.CONTRIBUTOR`).
+
+Invariants after the change:
+
+1. `SourceContribution.role` (model) is never `None`.
+2. `SourceContribution.role` (graph property) is always set (enum name, default
+   `"CONTRIBUTOR"`).
+3. `Contribution.roles` (graph property and outbound payload) is never empty.
+
+## Design
+
+### A. Default at the `SourceContribution` model level
+
+Make the default a model invariant so every producer (inbound message parsing **and**
+graph hydration) benefits without duplicating the rule:
+
+- `role: LocContributionRole = LocContributionRole.CONTRIBUTOR` (no longer `Optional`);
+- `validate_role` keeps its current logic but returns
+  `LocContributionRole.CONTRIBUTOR` instead of `None` in both null cases (absent role and
+  unrecognized URI — keep the error log for the latter);
+- `SourceRecordDAO._hydrate_contributions` no longer needs the `role = None` fallbacks:
+  a missing or unrecognized property hydrates to `CONTRIBUTOR`.
+
+`SourceRecordDAO._create_contribution_transaction` can drop the `if ... else None` guard
+(`role=source_contribution.role.name`); `create_source_contribution.cypher` is unchanged.
+
+Rationale for defaulting the unrecognized-URI case too: the alternative (keeping `None`)
+would preserve the very state this issue removes; a generic Contributor role plus the
+existing error log loses no information that the graph was keeping anyway.
+
+### B. Generic-role dedup in the document merge
+
+With the default in place, a person harvested with `aut` from one source and no role from
+another would collect `roles = [AUTHOR, CONTRIBUTOR]`. Since Contributor is the generic
+fallback (and is implied by any specific relator), `_get_roles_by_harvester_order`
+drops `CONTRIBUTOR` whenever at least one other role was collected: it is kept only when
+it is the sole role. This also applies to genuine harvested `ctb` roles, which is
+semantically harmless (`aut` subsumes `ctb`).
+
+### C. Default in `ContributionUpdateService.reconcile`
+
+Replace `roles = contribution.get("roles") or []` with a default to
+`[LocContributionRole.CONTRIBUTOR.value]` when the message provides no non-empty role
+list, so the sovisuplus path upholds invariant 3 as well.
+
+### Out of scope: data migration
+
+No migration of existing null-role `SourceContribution` / empty-roles `Contribution`
+nodes: the Neo4j database will be wiped and reloaded, so only newly written data
+matters.
+
+## Tests
+
+All tests run against the real Neo4j test instance (`APP_ENV=TEST pytest`).
+
+1. **Model default**: `SourceContribution` built with `role` absent, `role=None`, and an
+   unrecognized role URL all end with `role == LocContributionRole.CONTRIBUTOR`; a valid
+   role URL still maps to its relator.
+2. **Source-layer roundtrip**: persisting a source record whose contribution has no role
+   stores `sc.role = 'CONTRIBUTOR'`; hydrating a `SourceContribution` node without a
+   `role` property (defensive case) yields `CONTRIBUTOR`.
+3. **Merge, sole default**: a document whose only source record (idref-like fixture with
+   roleless contributions) is merged → each `Contribution.roles ==
+   ['http://id.loc.gov/vocabulary/relators/ctb']`.
+4. **Merge, generic-role dedup**: same person with `aut` from one source record and no
+   role from another → `Contribution.roles == ['.../aut']` (no `ctb`); a person with a
+   genuine `ctb` plus `aut` also ends with `['.../aut']`.
+5. **Contribution-update path**: a sovisuplus contribution-update message with missing or
+   empty `roles` produces a contribution with `roles == ['.../ctb']`; a message with
+   explicit roles is untouched.
+6. **Outbound payload**: the document event built from case 3 carries the `ctb` role
+   (no empty `roles` list).

--- a/tests/test_models/test_source_record_contributions.py
+++ b/tests/test_models/test_source_record_contributions.py
@@ -1,6 +1,8 @@
 from app.models.harvesting_sources import HarvestingSource
 from app.models.loc_contribution_role import LocContributionRole
+from app.models.source_contributions import SourceContribution
 from app.models.source_organizations import SourceOrganization
+from app.models.source_people import SourcePerson
 from app.models.source_records import SourceRecord
 
 def test_hal_chapter_source_record(
@@ -45,3 +47,60 @@ def test_hal_chapter_source_record(
         i.type == 'ror' and i.value == 'https://ror.org/000000000'
         for i in organisation_0.identifiers
     )
+
+
+def _minimal_contributor() -> dict:
+    return {
+        "source": "idref",
+        "source_identifier": "123456789",
+        "name": "Alice Dupont",
+    }
+
+
+def test_contribution_without_role_defaults_to_contributor():
+    """
+    Given a source contribution without a role
+    When the model is built
+    Then the role defaults to the generic Contributor role
+    """
+    contribution = SourceContribution(contributor=SourcePerson(**_minimal_contributor()))
+    assert contribution.role == LocContributionRole.CONTRIBUTOR
+
+
+def test_contribution_with_null_role_defaults_to_contributor():
+    """
+    Given a source contribution with an explicit null role
+    When the model is built
+    Then the role defaults to the generic Contributor role
+    """
+    contribution = SourceContribution(
+        role=None,
+        contributor=SourcePerson(**_minimal_contributor())
+    )
+    assert contribution.role == LocContributionRole.CONTRIBUTOR
+
+
+def test_contribution_with_unknown_role_defaults_to_contributor():
+    """
+    Given a source contribution with a role URL outside the LoC relators vocabulary
+    When the model is built
+    Then the role defaults to the generic Contributor role
+    """
+    contribution = SourceContribution(
+        role="https://id.loc.gov/vocabulary/relators/xxx.html",
+        contributor=SourcePerson(**_minimal_contributor())
+    )
+    assert contribution.role == LocContributionRole.CONTRIBUTOR
+
+
+def test_contribution_with_valid_role_is_kept():
+    """
+    Given a source contribution with a valid LoC role URL
+    When the model is built
+    Then the role maps to the corresponding relator
+    """
+    contribution = SourceContribution(
+        role="https://id.loc.gov/vocabulary/relators/aut.html",
+        contributor=SourcePerson(**_minimal_contributor())
+    )
+    assert contribution.role == LocContributionRole.AUTHOR

--- a/tests/test_services/test_contribution_default_role.py
+++ b/tests/test_services/test_contribution_default_role.py
@@ -1,0 +1,221 @@
+import json
+from typing import cast
+
+from app.config import get_app_settings
+from app.graph.generic.abstract_dao_factory import AbstractDAOFactory
+from app.graph.neo4j.document_dao import DocumentDAO
+from app.graph.neo4j.neo4j_connexion import Neo4jConnexion
+from app.models.agent_identifiers import PersonIdentifier
+from app.models.document import Document
+from app.models.loc_contribution_role import LocContributionRole
+from app.models.people import Person
+from app.services.documents.document_service import DocumentService
+from app.services.source_records.source_record_service import SourceRecordService
+from tests.fixtures.common import _source_record_from_json_data
+
+CTB = LocContributionRole.CONTRIBUTOR
+AUT = LocContributionRole.AUTHOR
+
+
+def _strip_roles(source_record_json_data: dict) -> dict:
+    for contribution in source_record_json_data["contributions"]:
+        contribution.pop("role", None)
+    return source_record_json_data
+
+
+def _set_roles(source_record_json_data: dict, role_url: str) -> dict:
+    for contribution in source_record_json_data["contributions"]:
+        contribution["role"] = role_url
+    return source_record_json_data
+
+
+def _document_dao() -> DocumentDAO:
+    factory = AbstractDAOFactory().get_dao_factory("neo4j")
+    return cast(DocumentDAO, factory.get_dao(Document))
+
+
+async def _stored_source_roles(source_record_uid: str) -> list:
+    query = (
+        "MATCH (:SourceRecord {uid: $uid})-[:HAS_CONTRIBUTION]->(sc:SourceContribution) "
+        "RETURN collect(sc.role) AS roles"
+    )
+    async with Neo4jConnexion().get_driver() as driver:
+        async with driver.session() as session:
+            result = await session.run(query, uid=source_record_uid)
+            record = await result.single()
+            return record["roles"]
+
+
+async def test_source_record_without_roles_stores_contributor(
+        test_app,  # pylint: disable=unused-argument
+        persisted_person_a_pydantic_model: Person,
+        article_exoplanet_from_oa_source_record_json_data: dict,
+        default_identifier_used: PersonIdentifier
+) -> None:
+    """
+    Given a source record whose contributions carry no role
+    When the source record is persisted and read back
+    Then every source contribution has the generic Contributor role,
+    stored as the 'CONTRIBUTOR' property on the SourceContribution node
+    """
+    record = _source_record_from_json_data(
+        _strip_roles(article_exoplanet_from_oa_source_record_json_data))
+    service = SourceRecordService()
+    await service.create_source_record(
+        source_record=record,
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
+    fetched = await service.get_source_record(record.uid)
+    assert fetched is not None
+    assert len(fetched.contributions) == 3
+    assert all(contribution.role == CTB for contribution in fetched.contributions)
+    assert await _stored_source_roles(record.uid) == ["CONTRIBUTOR"] * 3
+
+
+async def test_source_contribution_without_role_property_hydrates_as_contributor(
+        test_app,  # pylint: disable=unused-argument
+        persisted_person_a_pydantic_model: Person,
+        article_exoplanet_from_oa_source_record_json_data: dict,
+        default_identifier_used: PersonIdentifier
+) -> None:
+    """
+    Given a persisted SourceContribution node whose role property has been removed
+    When the source record is read back
+    Then the contribution hydrates with the generic Contributor role (defensive case)
+    """
+    record = _source_record_from_json_data(article_exoplanet_from_oa_source_record_json_data)
+    service = SourceRecordService()
+    await service.create_source_record(
+        source_record=record,
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
+    query = (
+        "MATCH (:SourceRecord {uid: $uid})-[:HAS_CONTRIBUTION]->(sc:SourceContribution) "
+        "REMOVE sc.role"
+    )
+    async with Neo4jConnexion().get_driver() as driver:
+        async with driver.session() as session:
+            await session.run(query, uid=record.uid)
+    fetched = await service.get_source_record(record.uid)
+    assert fetched is not None
+    assert len(fetched.contributions) == 3
+    assert all(contribution.role == CTB for contribution in fetched.contributions)
+
+
+async def test_document_contributions_default_to_contributor(
+        test_app,  # pylint: disable=unused-argument
+        persisted_person_a_pydantic_model: Person,
+        article_exoplanet_from_oa_source_record_json_data: dict,
+        default_identifier_used: PersonIdentifier
+) -> None:
+    """
+    Given a document built from a single source record whose contributions carry no role
+    When the document is read back
+    Then every contribution has exactly the generic Contributor role
+    """
+    record = _source_record_from_json_data(
+        _strip_roles(article_exoplanet_from_oa_source_record_json_data))
+    await SourceRecordService().create_source_record(
+        source_record=record,
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
+    document = await _document_dao().get_document_by_source_record_uid(record.uid)
+    assert document is not None
+    assert len(document.contributions) == 3
+    assert all(contribution.roles == [CTB] for contribution in document.contributions)
+
+
+async def test_generic_role_dropped_when_specific_role_present(
+        test_app,  # pylint: disable=unused-argument
+        persisted_person_a_pydantic_model: Person,
+        article_exoplanet_from_oa_source_record_json_data: dict,
+        article_exoplanet_from_scanr_source_record_json_data: dict,
+        default_identifier_used: PersonIdentifier
+) -> None:
+    """
+    Given two equivalent source records, one with Author roles
+    and one whose contributions carry no role (defaulting to Contributor)
+    When the document is built from both
+    Then every contribution keeps only the Author role
+    """
+    service = SourceRecordService()
+    oa_record = _source_record_from_json_data(article_exoplanet_from_oa_source_record_json_data)
+    await service.create_source_record(
+        source_record=oa_record,
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
+    scanr_record = _source_record_from_json_data(
+        _strip_roles(article_exoplanet_from_scanr_source_record_json_data))
+    await service.create_source_record(
+        source_record=scanr_record,
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
+    document = await _document_dao().get_document_by_source_record_uid(oa_record.uid)
+    assert document is not None
+    assert len(document.contributions) == 3
+    assert all(contribution.roles == [AUT] for contribution in document.contributions)
+
+
+async def test_genuine_contributor_role_dropped_when_specific_role_present(
+        test_app,  # pylint: disable=unused-argument
+        persisted_person_a_pydantic_model: Person,
+        article_exoplanet_from_oa_source_record_json_data: dict,
+        article_exoplanet_from_scanr_source_record_json_data: dict,
+        default_identifier_used: PersonIdentifier
+) -> None:
+    """
+    Given two equivalent source records, one with Author roles
+    and one with genuine harvested Contributor roles
+    When the document is built from both
+    Then every contribution keeps only the Author role
+    """
+    service = SourceRecordService()
+    oa_record = _source_record_from_json_data(article_exoplanet_from_oa_source_record_json_data)
+    await service.create_source_record(
+        source_record=oa_record,
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
+    scanr_record = _source_record_from_json_data(
+        _set_roles(article_exoplanet_from_scanr_source_record_json_data,
+                   "https://id.loc.gov/vocabulary/relators/ctb.html"))
+    await service.create_source_record(
+        source_record=scanr_record,
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
+    document = await _document_dao().get_document_by_source_record_uid(oa_record.uid)
+    assert document is not None
+    assert len(document.contributions) == 3
+    assert all(contribution.roles == [AUT] for contribution in document.contributions)
+
+
+async def test_document_event_payload_carries_contributor_role(
+        test_app,
+        mocked_exchange,
+        persisted_person_a_pydantic_model: Person,
+        article_exoplanet_from_oa_source_record_json_data: dict,
+        default_identifier_used: PersonIdentifier
+) -> None:
+    """
+    Given a document built from a source record whose contributions carry no role
+    When the document created event is published
+    Then the payload contributions carry the Contributor role (never an empty roles list)
+    """
+    record = _source_record_from_json_data(
+        _strip_roles(article_exoplanet_from_oa_source_record_json_data))
+    await SourceRecordService().create_source_record(
+        source_record=record,
+        harvested_for=persisted_person_a_pydantic_model,
+        identifier_used=default_identifier_used)
+    document = await _document_dao().get_document_by_source_record_uid(record.uid)
+    assert document is not None
+    test_app.amqp_interface.pika_exchanges[
+        get_app_settings().amqp_graph_exchange_name] = mocked_exchange
+    await DocumentService().signal_document_created(document.uid)
+    mocked_exchange.publish.assert_called_once()
+    message = mocked_exchange.publish.call_args[1]["message"]
+    message_payload = json.loads(message.body.decode())
+    contributions = message_payload["fields"]["contributions"]
+    assert len(contributions) == 3
+    assert all(
+        contribution["roles"] == ["LocContributionRole.CONTRIBUTOR"]
+        for contribution in contributions)

--- a/tests/test_services/test_contribution_update_service.py
+++ b/tests/test_services/test_contribution_update_service.py
@@ -431,3 +431,58 @@ async def test_affiliation_hal_structid_becomes_identifier(
         _contributions_change(document.uid, contributions))
 
     assert ("hal", "1210550") in await _affiliation_identifiers(document.uid)
+
+
+async def _contribution_roles_by_person(document_uid: str) -> dict:
+    query = (
+        "MATCH (:Document {uid: $uid})-[:HAS_CONTRIBUTION]->(c:Contribution)"
+        "<-[:HAS_CONTRIBUTION]-(p:Person) RETURN p.uid AS person_uid, c.roles AS roles"
+    )
+    async with Neo4jConnexion().get_driver() as driver:
+        async with driver.session() as session:
+            result = await session.run(query, uid=document_uid)
+            return {record["person_uid"]: record["roles"] async for record in result}
+
+
+@pytest.mark.asyncio
+async def test_contribution_without_roles_defaults_to_contributor(
+        test_app,  # pylint: disable=unused-argument
+        document_hal_article_a_persisted_model: Document,
+        persisted_person_a_pydantic_model: Person,
+        mocked_document_updated_signal) -> None:  # pylint: disable=unused-argument
+    """
+    Given a contributions change carrying one contribution with empty roles,
+    one without a roles field and one with an explicit role,
+    When the change is applied,
+    Then the roleless contributions default to the generic Contributor role
+    and the explicit role is kept untouched.
+    """
+    document = document_hal_article_a_persisted_model
+    internal = persisted_person_a_pydantic_model
+    contributions = [
+        {
+            "rank": 0, "roles": [],
+            "person": {"uid": internal.uid, "displayName": internal.display_name,
+                       "identifiers": []},
+            "affiliations": [],
+        },
+        {
+            "rank": 1,
+            "person": {"uid": None, "displayName": "Claire Durand",
+                       "identifiers": [{"type": "orcid", "value": "0000-0000-0000-0002"}]},
+            "affiliations": [],
+        },
+        {
+            "rank": 2, "roles": [AUT],
+            "person": {"uid": None, "displayName": "Paul Petit",
+                       "identifiers": [{"type": "orcid", "value": "0000-0000-0000-0003"}]},
+            "affiliations": [],
+        },
+    ]
+    await ChangeService().create_and_apply_change(
+        _contributions_change(document.uid, contributions))
+
+    roles_by_person = await _contribution_roles_by_person(document.uid)
+    assert roles_by_person[internal.uid] == [CTB]
+    assert roles_by_person["orcid-0000-0000-0000-0002"] == [CTB]
+    assert roles_by_person["orcid-0000-0000-0000-0003"] == [AUT]


### PR DESCRIPTION
Closes #414

- `SourceContribution.role` is non-optional and defaults to the generic LoC Contributor role (`ctb`), both when the harvested role is absent and when the role URL is not a known LoC relator (error still logged)
- source-layer write always stores the role property; hydration falls back to `CONTRIBUTOR` when the property is missing or unrecognized
- at document merge, the generic Contributor role is kept only when it is the sole role (dropped when a specific role is present)
- sovisuplus contribution-update messages with missing/empty `roles` default to `[ctb]`
- no data migration: the Neo4j database will be wiped and reloaded

Spec: `specs/set-default-sourcecontribution-role-to-contributor-when-null#414/prompt.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)